### PR TITLE
Modify Request Class to Match UML

### DIFF
--- a/app/src/main/java/com/example/atheneum/Request.java
+++ b/app/src/main/java/com/example/atheneum/Request.java
@@ -32,7 +32,6 @@ public class Request {
      * Instantiates a new Request.
      */
     public Request() {
-        this.bookID = UUID.randomUUID();
         this.rStatus = Status.PENDING;
     }
 
@@ -41,9 +40,9 @@ public class Request {
      *
      * @param requester the requester
      */
-    public Request(User requester) {
+    public Request(User requester, UUID bookID) {
         this.requester = requester;
-        this.bookID = UUID.randomUUID();
+        this.bookID = bookID;
         this.rStatus = Status.PENDING;
     }
 

--- a/app/src/test/java/com/example/atheneum/RequestTest.java
+++ b/app/src/test/java/com/example/atheneum/RequestTest.java
@@ -13,12 +13,13 @@ import static org.junit.Assert.assertEquals;
 public class RequestTest {
     private User requester;
     private Request newRequest;
+    private UUID bookID;
 
     @Before
     public void setUp() throws Exception {
         requester = new User();
-
-        newRequest = new Request(requester);
+        bookID = UUID.randomUUID();
+        newRequest = new Request(requester, bookID);
     }
 
     @Test
@@ -28,7 +29,7 @@ public class RequestTest {
 
     @Test
     public void getBookID() {
-        assertTrue(newRequest.getBookID() instanceof UUID);
+        Assert.assertThat(newRequest.getBookID(), is(bookID));
     }
 
     @Test


### PR DESCRIPTION
The current request class doesn't match the UML diagram closely. In addition, it doesn't make sense for the request class to generate a random bookID in the constructer since only requests on books already on the system can be made. So it makes more sense in the context of the  app to take in the bookID as a parameter.