### PR TITLE
Add edit book

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.7.22'
     // required if you want to use Mockito for Android tests
     androidTestImplementation 'org.mockito:mockito-android:2.7.22'
+    implementation 'com.android.support:design:28.0.0'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/com/example/atheneum/activities/MainActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/MainActivity.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 import com.example.atheneum.R;
 import com.example.atheneum.fragments.AddBookFragment;
 import com.example.atheneum.fragments.HomeFragment;
+import com.example.atheneum.fragments.OwnerPageFragment;
 import com.example.atheneum.fragments.ViewProfileFragment;
 import com.firebase.ui.auth.AuthUI;
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -86,7 +87,7 @@ public class MainActivity extends AppCompatActivity
         } else if (id == R.id.nav_addbook)  {
             fragmentManager.beginTransaction().replace(R.id.content_frame, new AddBookFragment()).commit();
         } else if (id == R.id.nav_owner) {
-
+            fragmentManager.beginTransaction().replace(R.id.content_frame, new OwnerPageFragment()).commit();
         } else if (id == R.id.nav_borrower) {
 
         } else if (id == R.id.nav_logout) {

--- a/app/src/main/java/com/example/atheneum/activities/MainActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/MainActivity.java
@@ -16,6 +16,7 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.example.atheneum.R;
+import com.example.atheneum.fragments.AddBookFragment;
 import com.example.atheneum.fragments.HomeFragment;
 import com.example.atheneum.fragments.ViewProfileFragment;
 import com.firebase.ui.auth.AuthUI;
@@ -82,6 +83,8 @@ public class MainActivity extends AppCompatActivity
             fragmentManager.beginTransaction().replace(R.id.content_frame, new HomeFragment()).commit();
         } else if (id == R.id.nav_profile) {
             fragmentManager.beginTransaction().replace(R.id.content_frame, new ViewProfileFragment()).commit();
+        } else if (id == R.id.nav_addbook)  {
+            fragmentManager.beginTransaction().replace(R.id.content_frame, new AddBookFragment()).commit();
         } else if (id == R.id.nav_owner) {
 
         } else if (id == R.id.nav_borrower) {
@@ -102,5 +105,11 @@ public class MainActivity extends AppCompatActivity
         DrawerLayout drawer = (DrawerLayout) findViewById(R.id.drawer_layout);
         drawer.closeDrawer(GravityCompat.START);
         return true;
+    }
+
+    // allows for setting title of action bar from different fragmenets
+    // taken from https://stackoverflow.com/questions/15560904/setting-custom-actionbar-title-from-fragment
+    public void setActionBarTitle(String title) {
+        getSupportActionBar().setTitle(title);
     }
 }

--- a/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
@@ -2,18 +2,45 @@ package com.example.atheneum.fragments;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
 
 import com.example.atheneum.R;
 import com.example.atheneum.activities.MainActivity;
+import com.example.atheneum.models.Book;
+import com.example.atheneum.models.User;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
 
 public class AddBookFragment extends Fragment {
     private View view;
     private MainActivity mainActivity;
     private Context context;
+
+    private User owner;
+    private Book newBook;
+
+    // references for the various entry fields
+    private EditText titleEditText;
+    private EditText authorEditText;
+    private EditText isbnEditText;
+    private EditText descEditText;
+
+    private FloatingActionButton saveBtn;
+    private Button scanIsbnBtn;
+    private Button autoPopulateByIsgnBtn;
 
 
     public AddBookFragment() {
@@ -27,11 +54,129 @@ public class AddBookFragment extends Fragment {
         this.view = inflater.inflate(R.layout.fragment_add_edit_book, container, false);
 
         this.context = getContext();
+
+        // bind editText references to UI elements
+        titleEditText = this.view.findViewById(R.id.bookTitleEditText);
+        authorEditText = this.view.findViewById(R.id.authorEditText);
+        isbnEditText = this.view.findViewById(R.id.isbnEditText);
+        descEditText = this.view.findViewById(R.id.descEditText);
+
+        saveBtn = this.view.findViewById(R.id.saveBookBtn);
+        saveBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                saveNewBook();
+            }
+        });
+        scanIsbnBtn = this.view.findViewById(R.id.scanIsbnButton);
+        scanIsbnBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                scanIsbn();
+            }
+        });
+        autoPopulateByIsgnBtn = this.view.findViewById(R.id.populateFromIsbnBtn);
+        autoPopulateByIsgnBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                populateFieldsByIsbn();
+            }
+        });
+
         mainActivity = (MainActivity) getActivity();
         // set action bar title
         mainActivity.setActionBarTitle(context.getResources().getString(R.string.add_book_prompt));
 
         return this.view;
+    }
+
+    public void scanIsbn() {
+        Log.i("AddBook", "AddBook*** ISBN scan requested");
+        // TODO
+    }
+
+    public void populateFieldsByIsbn() {
+        // TODO: FINISH
+
+        Log.i("AddBook", "AddBook*** Auto-populate requested");
+        long isbn = -1;
+        if (!isbnEditText.getText().toString().equals("")) {
+             isbn = Integer.parseInt(isbnEditText.getText().toString());
+
+        }
+        else {
+            Log.i("AddBook", "AddBook*** No ISBN ");
+            // TODO: Print error message
+
+        }
+
+    }
+
+    public boolean allFieldsFilled() {
+        String title = titleEditText.getText().toString();
+        String author = authorEditText.getText().toString();
+        String isbn = isbnEditText.getText().toString();
+        String desc = descEditText.getText().toString();
+
+        boolean allFilled = !title.equals("") && !author.equals("") && !isbn.equals("")
+                && desc.equals("");
+
+        return allFilled;
+    }
+
+    public void saveNewBook() {
+        Log.i("AddBook", "AddBook*** Save Button Pressed");
+
+        if (allFieldsFilled()) {
+            String title = titleEditText.getText().toString();
+            String author = authorEditText.getText().toString();
+            long isbn = Long.parseLong(isbnEditText.getText().toString());
+            String desc = descEditText.getText().toString();
+
+            // get user from Firebase auth
+            FirebaseAuth auth = FirebaseAuth.getInstance();
+            FirebaseUser firebaseUser = FirebaseAuth.getInstance().getCurrentUser();
+            final FirebaseDatabase db = FirebaseDatabase.getInstance();
+
+            if (firebaseUser != null) {
+                DatabaseReference ref = db.getReference().child(getString(R.string.db_users)).child(firebaseUser.getUid());
+                // retrieve user object from database
+                ref.addListenerForSingleValueEvent(new ValueEventListener() {
+                    @Override
+                    public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
+                        Log.i("AddBook", "AddBook*** Reading for user");
+                        if (dataSnapshot.exists()) {
+                            owner = dataSnapshot.getValue(User.class);
+
+                        } else {
+                            Log.w("AddBook", "AddBook*** Current User doesn't exist in database!");
+                        }
+
+                    }
+
+                    @Override
+                    public void onCancelled(@NonNull DatabaseError databaseError) {
+                        Log.w("AddBook", "AddBook*** User listener was cancelled");
+                    }
+                });
+
+            } else {
+                Log.w("AddBook", "AddBook*** ERROR UNAUTH USER : User should be authenticated if the user is in this activity!");
+            }
+
+            newBook = new Book(isbn, title, desc, author, owner, null, Book.Status.AVAILABLE);
+
+            // add book to the owner's collection
+            DatabaseReference ownerColref = db.getReference().child(getString(R.string.db_ownerCollection)).child(owner.getUserID());
+            ownerColref.child(newBook.getBookID().toString()).setValue(newBook);
+            Log.i("AddBook", "Book added, id=" + newBook.getBookID().toString());
+
+        }
+        else {
+            // TODO : Display Error Prompt
+            Log.w("AddBook", "AddBook*** Error fields unfilled");
+        }
+
     }
 
 }

--- a/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
@@ -91,10 +91,11 @@ public class AddBookFragment extends Fragment {
                 populateFieldsByIsbn();
             }
         });
-
-        mainActivity = (MainActivity) getActivity();
-        // set action bar title
-        mainActivity.setActionBarTitle(context.getResources().getString(R.string.add_book_prompt));
+        if (getActivity() instanceof MainActivity) {
+            mainActivity = (MainActivity) getActivity();
+            // set action bar title
+            mainActivity.setActionBarTitle(context.getResources().getString(R.string.add_book_prompt));
+        }
 
         return this.view;
     }
@@ -169,12 +170,13 @@ public class AddBookFragment extends Fragment {
                             // hide keyboard and close fragment
                             // keyboard hiding taken from:
                             // https://stackoverflow.com/questions/1109022/close-hide-the-android-soft-keyboard
-                            InputMethodManager imm = (InputMethodManager) mainActivity.getSystemService(Activity.INPUT_METHOD_SERVICE);
-                            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
-                            mainActivity.getSupportFragmentManager().beginTransaction().remove(AddBookFragment.this).commit();
 
-                            // return to home page fragment
-                            mainActivity.getSupportFragmentManager().beginTransaction().replace(R.id.content_frame, new HomeFragment()).commit();
+                            InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Activity.INPUT_METHOD_SERVICE);
+                            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+                            getActivity().getSupportFragmentManager().beginTransaction().remove(AddBookFragment.this).commit();
+
+                            // return to owner page fragment
+                            getActivity().getSupportFragmentManager().beginTransaction().replace(R.id.content_frame, new OwnerPageFragment()).commit();
 
 
                         } else {

--- a/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
@@ -132,17 +132,21 @@ public class AddBookFragment extends Fragment {
         Log.i("AddBook", "AddBook*** Save Button Pressed");
 
         if (allFieldsFilled()) {
+            Log.i("AddBook", "AddBook*** Fields checked, all filled");
+
             title = titleEditText.getText().toString();
             author = authorEditText.getText().toString();
             isbn = Long.parseLong(isbnEditText.getText().toString());
             desc = descEditText.getText().toString();
 
             // get user from Firebase auth
-            FirebaseAuth auth = FirebaseAuth.getInstance();
+//            FirebaseAuth auth = FirebaseAuth.getInstance();
             FirebaseUser firebaseUser = FirebaseAuth.getInstance().getCurrentUser();
             final FirebaseDatabase db = FirebaseDatabase.getInstance();
 
             if (firebaseUser != null) {
+                Log.i("AddBook", "AddBook*** not null firebaseuser");
+
                 DatabaseReference ref = db.getReference().child(getString(R.string.db_users)).child(firebaseUser.getUid());
                 // retrieve user object from database
                 ref.addListenerForSingleValueEvent(new ValueEventListener() {
@@ -160,6 +164,9 @@ public class AddBookFragment extends Fragment {
                             ownerColref.child(newBook.getBookID().toString()).setValue(newBook);
                             Log.i("AddBook", "Book added, id=" + newBook.getBookID().toString());
 
+                            // close fragment
+                            mainActivity.getFragmentManager().popBackStack();
+
                         } else {
                             Log.w("AddBook", "AddBook*** Current User doesn't exist in database!");
                         }
@@ -173,7 +180,7 @@ public class AddBookFragment extends Fragment {
                 });
 
             } else {
-                Log.w("AddBook", "AddBook*** ERROR UNAUTH USER : User should be authenticated if the user is in this activity!");
+                Log.w("AddBook", "AddBook*** ERROR UNAUTH USER : User should be authenticated if the user is in this screen!");
             }
 
 

--- a/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
@@ -1,0 +1,37 @@
+package com.example.atheneum.fragments;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.atheneum.R;
+import com.example.atheneum.activities.MainActivity;
+
+public class AddBookFragment extends Fragment {
+    private View view;
+    private MainActivity mainActivity;
+    private Context context;
+
+
+    public AddBookFragment() {
+        // required empty constructor
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        this.view = inflater.inflate(R.layout.fragment_add_edit_book, container, false);
+
+        this.context = getContext();
+        mainActivity = (MainActivity) getActivity();
+        // set action bar title
+        mainActivity.setActionBarTitle(context.getResources().getString(R.string.add_book_prompt));
+
+        return this.view;
+    }
+
+}

--- a/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
@@ -31,6 +31,10 @@ public class AddBookFragment extends Fragment {
 
     private User owner;
     private Book newBook;
+    String title;
+    String author;
+    long isbn;
+    String desc;
 
     // references for the various entry fields
     private EditText titleEditText;
@@ -99,7 +103,7 @@ public class AddBookFragment extends Fragment {
         // TODO: FINISH
 
         Log.i("AddBook", "AddBook*** Auto-populate requested");
-        long isbn = -1;
+        this.isbn = -1;
         if (!isbnEditText.getText().toString().equals("")) {
              isbn = Integer.parseInt(isbnEditText.getText().toString());
 
@@ -119,7 +123,7 @@ public class AddBookFragment extends Fragment {
         String desc = descEditText.getText().toString();
 
         boolean allFilled = !title.equals("") && !author.equals("") && !isbn.equals("")
-                && desc.equals("");
+                && !desc.equals("");
 
         return allFilled;
     }
@@ -128,10 +132,10 @@ public class AddBookFragment extends Fragment {
         Log.i("AddBook", "AddBook*** Save Button Pressed");
 
         if (allFieldsFilled()) {
-            String title = titleEditText.getText().toString();
-            String author = authorEditText.getText().toString();
-            long isbn = Long.parseLong(isbnEditText.getText().toString());
-            String desc = descEditText.getText().toString();
+            title = titleEditText.getText().toString();
+            author = authorEditText.getText().toString();
+            isbn = Long.parseLong(isbnEditText.getText().toString());
+            desc = descEditText.getText().toString();
 
             // get user from Firebase auth
             FirebaseAuth auth = FirebaseAuth.getInstance();
@@ -147,6 +151,14 @@ public class AddBookFragment extends Fragment {
                         Log.i("AddBook", "AddBook*** Reading for user");
                         if (dataSnapshot.exists()) {
                             owner = dataSnapshot.getValue(User.class);
+                            Log.i("AddBook", "AddBook*** Got a user");
+
+                            newBook = new Book(isbn, title, desc, author, owner, null, Book.Status.AVAILABLE);
+
+                            // add book to the owner's collection
+                            DatabaseReference ownerColref = db.getReference().child(getString(R.string.db_ownerCollection)).child(owner.getUserID());
+                            ownerColref.child(newBook.getBookID().toString()).setValue(newBook);
+                            Log.i("AddBook", "Book added, id=" + newBook.getBookID().toString());
 
                         } else {
                             Log.w("AddBook", "AddBook*** Current User doesn't exist in database!");
@@ -164,12 +176,7 @@ public class AddBookFragment extends Fragment {
                 Log.w("AddBook", "AddBook*** ERROR UNAUTH USER : User should be authenticated if the user is in this activity!");
             }
 
-            newBook = new Book(isbn, title, desc, author, owner, null, Book.Status.AVAILABLE);
 
-            // add book to the owner's collection
-            DatabaseReference ownerColref = db.getReference().child(getString(R.string.db_ownerCollection)).child(owner.getUserID());
-            ownerColref.child(newBook.getBookID().toString()).setValue(newBook);
-            Log.i("AddBook", "Book added, id=" + newBook.getBookID().toString());
 
         }
         else {

--- a/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
@@ -1,5 +1,6 @@
 package com.example.atheneum.fragments;
 
+import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -9,6 +10,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 
@@ -164,8 +166,12 @@ public class AddBookFragment extends Fragment {
                             ownerColref.child(newBook.getBookID().toString()).setValue(newBook);
                             Log.i("AddBook", "Book added, id=" + newBook.getBookID().toString());
 
-                            // close fragment
-                            mainActivity.getFragmentManager().popBackStack();
+                            // hide keyboard and close fragment
+                            // keyboard hiding taken from:
+                            // https://stackoverflow.com/questions/1109022/close-hide-the-android-soft-keyboard
+                            InputMethodManager imm = (InputMethodManager) mainActivity.getSystemService(Activity.INPUT_METHOD_SERVICE);
+                            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+                            mainActivity.getSupportFragmentManager().beginTransaction().remove(AddBookFragment.this).commit();
 
                         } else {
                             Log.w("AddBook", "AddBook*** Current User doesn't exist in database!");
@@ -178,6 +184,8 @@ public class AddBookFragment extends Fragment {
                         Log.w("AddBook", "AddBook*** User listener was cancelled");
                     }
                 });
+
+
 
             } else {
                 Log.w("AddBook", "AddBook*** ERROR UNAUTH USER : User should be authenticated if the user is in this screen!");

--- a/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.Fragment;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -47,6 +48,8 @@ public class AddBookFragment extends Fragment {
     private FloatingActionButton saveBtn;
     private Button scanIsbnBtn;
     private Button autoPopulateByIsgnBtn;
+
+    private static final String TAG = "AddBook";
 
 
     public AddBookFragment() {
@@ -97,21 +100,21 @@ public class AddBookFragment extends Fragment {
     }
 
     public void scanIsbn() {
-        Log.i("AddBook", "AddBook*** ISBN scan requested");
+        Log.i(TAG, "AddBook*** ISBN scan requested");
         // TODO
     }
 
     public void populateFieldsByIsbn() {
         // TODO: FINISH
 
-        Log.i("AddBook", "AddBook*** Auto-populate requested");
-        this.isbn = -1;
-        if (!isbnEditText.getText().toString().equals("")) {
+        Log.i(TAG, "AddBook*** Auto-populate requested");
+        this.isbn = Book.INVALILD_ISBN;
+        if (!TextUtils.isEmpty(isbnEditText.getText())) {
              isbn = Integer.parseInt(isbnEditText.getText().toString());
 
         }
         else {
-            Log.i("AddBook", "AddBook*** No ISBN ");
+            Log.i(TAG, "AddBook*** No ISBN ");
             // TODO: Print error message
 
         }
@@ -119,22 +122,19 @@ public class AddBookFragment extends Fragment {
     }
 
     public boolean allFieldsFilled() {
-        String title = titleEditText.getText().toString();
-        String author = authorEditText.getText().toString();
-        String isbn = isbnEditText.getText().toString();
-        String desc = descEditText.getText().toString();
-
-        boolean allFilled = !title.equals("") && !author.equals("") && !isbn.equals("")
-                && !desc.equals("");
+        boolean allFilled = !TextUtils.isEmpty(titleEditText.getText()) &&
+                !TextUtils.isEmpty(authorEditText.getText()) &&
+                !TextUtils.isEmpty(isbnEditText.getText()) &&
+                !TextUtils.isEmpty(descEditText.getText());
 
         return allFilled;
     }
 
     public void saveNewBook() {
-        Log.i("AddBook", "AddBook*** Save Button Pressed");
+        Log.i(TAG, "AddBook*** Save Button Pressed");
 
         if (allFieldsFilled()) {
-            Log.i("AddBook", "AddBook*** Fields checked, all filled");
+            Log.i(TAG, "AddBook*** Fields checked, all filled");
 
             title = titleEditText.getText().toString();
             author = authorEditText.getText().toString();
@@ -147,24 +147,24 @@ public class AddBookFragment extends Fragment {
             final FirebaseDatabase db = FirebaseDatabase.getInstance();
 
             if (firebaseUser != null) {
-                Log.i("AddBook", "AddBook*** not null firebaseuser");
+                Log.i(TAG, "AddBook*** not null firebaseuser");
 
                 DatabaseReference ref = db.getReference().child(getString(R.string.db_users)).child(firebaseUser.getUid());
                 // retrieve user object from database
                 ref.addListenerForSingleValueEvent(new ValueEventListener() {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-                        Log.i("AddBook", "AddBook*** Reading for user");
+                        Log.i(TAG, "AddBook*** Reading for user");
                         if (dataSnapshot.exists()) {
                             owner = dataSnapshot.getValue(User.class);
-                            Log.i("AddBook", "AddBook*** Got a user");
+                            Log.i(TAG, "AddBook*** Got a user");
 
                             newBook = new Book(isbn, title, desc, author, owner, null, Book.Status.AVAILABLE);
 
                             // add book to the owner's collection
                             DatabaseReference ownerColref = db.getReference().child(getString(R.string.db_ownerCollection)).child(owner.getUserID());
                             ownerColref.child(newBook.getBookID().toString()).setValue(newBook);
-                            Log.i("AddBook", "Book added, id=" + newBook.getBookID().toString());
+                            Log.i(TAG, "Book added, id=" + newBook.getBookID().toString());
 
                             // hide keyboard and close fragment
                             // keyboard hiding taken from:
@@ -178,21 +178,21 @@ public class AddBookFragment extends Fragment {
 
 
                         } else {
-                            Log.w("AddBook", "AddBook*** Current User doesn't exist in database!");
+                            Log.w(TAG, "AddBook*** Current User doesn't exist in database!");
                         }
 
                     }
 
                     @Override
                     public void onCancelled(@NonNull DatabaseError databaseError) {
-                        Log.w("AddBook", "AddBook*** User listener was cancelled");
+                        Log.w(TAG, "AddBook*** User listener was cancelled");
                     }
                 });
 
 
 
             } else {
-                Log.w("AddBook", "AddBook*** ERROR UNAUTH USER : User should be authenticated if the user is in this screen!");
+                Log.w(TAG, "AddBook*** ERROR UNAUTH USER : User should be authenticated if the user is in this screen!");
             }
 
 
@@ -200,7 +200,7 @@ public class AddBookFragment extends Fragment {
         }
         else {
             // TODO : Display Error Prompt
-            Log.w("AddBook", "AddBook*** Error fields unfilled");
+            Log.w(TAG, "AddBook*** Error fields unfilled");
         }
 
     }

--- a/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/AddBookFragment.java
@@ -173,6 +173,10 @@ public class AddBookFragment extends Fragment {
                             imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
                             mainActivity.getSupportFragmentManager().beginTransaction().remove(AddBookFragment.this).commit();
 
+                            // return to home page fragment
+                            mainActivity.getSupportFragmentManager().beginTransaction().replace(R.id.content_frame, new HomeFragment()).commit();
+
+
                         } else {
                             Log.w("AddBook", "AddBook*** Current User doesn't exist in database!");
                         }

--- a/app/src/main/java/com/example/atheneum/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/HomeFragment.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.example.atheneum.R;
+import com.example.atheneum.activities.MainActivity;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -23,6 +24,10 @@ public class HomeFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+
+        // set title
+        ((MainActivity) getActivity()).setActionBarTitle(getContext().getResources().getString(R.string.app_name));
+
         // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_home, container, false);
     }

--- a/app/src/main/java/com/example/atheneum/fragments/OwnerPageFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/OwnerPageFragment.java
@@ -12,7 +12,7 @@ import com.example.atheneum.activities.MainActivity;
 
 public class OwnerPageFragment extends Fragment {
     private View view;
-    private MainActivity mainActivity;
+    private MainActivity mainActivity = null;
     private Context context;
 
     public OwnerPageFragment() {
@@ -27,9 +27,12 @@ public class OwnerPageFragment extends Fragment {
 
         this.context = getContext();
 
-        mainActivity = (MainActivity) getActivity();
-        // set action bar title
-        mainActivity.setActionBarTitle(context.getResources().getString(R.string.owner_page_title));
+        if (getActivity() instanceof  MainActivity) {
+            mainActivity = (MainActivity) getActivity();
+            // set action bar title
+            mainActivity.setActionBarTitle(context.getResources().getString(R.string.owner_page_title));
+            
+        }
 
         return this.view;
     }

--- a/app/src/main/java/com/example/atheneum/fragments/OwnerPageFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/OwnerPageFragment.java
@@ -1,0 +1,37 @@
+package com.example.atheneum.fragments;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.atheneum.R;
+import com.example.atheneum.activities.MainActivity;
+
+public class OwnerPageFragment extends Fragment {
+    private View view;
+    private MainActivity mainActivity;
+    private Context context;
+
+    public OwnerPageFragment() {
+        // required empty constructor
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        this.view = inflater.inflate(R.layout.fragment_owner_page, container, false);
+
+        this.context = getContext();
+
+        mainActivity = (MainActivity) getActivity();
+        // set action bar title
+        mainActivity.setActionBarTitle(context.getResources().getString(R.string.owner_page_title));
+
+        return this.view;
+    }
+
+}

--- a/app/src/main/java/com/example/atheneum/models/Book.java
+++ b/app/src/main/java/com/example/atheneum/models/Book.java
@@ -7,6 +7,8 @@ import java.util.UUID;
  * The Book class.
  */
 public class Book {
+    public static final long INVALILD_ISBN = -1;
+
     private long isbn;
     private String title = null;
     private String description = null;

--- a/app/src/main/res/drawable/ic_add_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_add_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/layout/app_bar.xml
+++ b/app/src/main/res/layout/app_bar.xml
@@ -16,7 +16,11 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
-            app:popupTheme="@style/AppTheme.PopupOverlay" />
+            app:popupTheme="@style/AppTheme.PopupOverlay">
+
+
+
+        </android.support.v7.widget.Toolbar>
 
     </android.support.design.widget.AppBarLayout>
 

--- a/app/src/main/res/layout/fragment_add_edit_book.xml
+++ b/app/src/main/res/layout/fragment_add_edit_book.xml
@@ -132,24 +132,27 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
                 android:text="@string/bookdesc_prompt"
-                app:layout_constraintBottom_toTopOf="@+id/descEditText"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/populateFromIsbnBtn" />
 
             <EditText
                 android:id="@+id/descEditText"
+                style="@style/Widget.MaterialComponents.TextInputEditText.OutlinedBox"
                 android:layout_width="0dp"
                 android:layout_height="150dp"
                 android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
                 android:layout_marginEnd="16dp"
                 android:layout_marginBottom="16dp"
                 android:ems="10"
                 android:hint="@string/bookdesc_prompt"
+                android:importantForAutofill="no"
                 android:inputType="textMultiLine"
+                android:gravity="top|left"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                android:importantForAutofill="no" />
+                app:layout_constraintTop_toBottomOf="@+id/descriptionPrompt" />
 
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_add_edit_book.xml
+++ b/app/src/main/res/layout/fragment_add_edit_book.xml
@@ -2,7 +2,6 @@
 
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -12,7 +11,7 @@
 
         <android.support.constraint.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="wrap_content">
 
             <ImageView
                 android:id="@+id/bookImage"
@@ -49,7 +48,8 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/bookTitlePrompt" />
+                app:layout_constraintTop_toBottomOf="@+id/bookTitlePrompt"
+                android:importantForAutofill="no" />
 
             <TextView
                 android:id="@+id/authorPrompt"
@@ -74,7 +74,8 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/authorPrompt" />
+                app:layout_constraintTop_toBottomOf="@+id/authorPrompt"
+                android:importantForAutofill="no" />
 
             <TextView
                 android:id="@+id/isbnPrompt"
@@ -91,7 +92,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="32dp"
-                android:text="Scan"
+                android:text="@string/scanBtnPrompt"
                 app:layout_constraintBaseline_toBaselineOf="@+id/isbnEditText"
                 app:layout_constraintEnd_toEndOf="parent" />
 
@@ -109,7 +110,8 @@
                 app:layout_constraintEnd_toStartOf="@+id/scanIsbnButton"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/isbnPrompt" />
+                app:layout_constraintTop_toBottomOf="@+id/isbnPrompt"
+                android:importantForAutofill="no" />
 
             <Button
                 android:id="@+id/populateFromIsbnBtn"
@@ -130,12 +132,12 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
                 android:text="@string/bookdesc_prompt"
-                app:layout_constraintBottom_toTopOf="@+id/editText4"
+                app:layout_constraintBottom_toTopOf="@+id/descEditText"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/populateFromIsbnBtn" />
 
             <EditText
-                android:id="@+id/editText4"
+                android:id="@+id/descEditText"
                 android:layout_width="0dp"
                 android:layout_height="150dp"
                 android:layout_marginStart="16dp"
@@ -146,7 +148,8 @@
                 android:inputType="textMultiLine"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
+                app:layout_constraintStart_toStartOf="parent"
+                android:importantForAutofill="no" />
 
         </android.support.constraint.ConstraintLayout>
 
@@ -162,6 +165,7 @@
         app:layout_anchorGravity="bottom|right|end"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:srcCompat="@android:drawable/ic_menu_save" />
+        app:srcCompat="@android:drawable/ic_menu_save"
+        android:focusable="true" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_add_edit_book.xml
+++ b/app/src/main/res/layout/fragment_add_edit_book.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <ImageView
+                android:id="@+id/bookImage"
+                android:layout_width="150dp"
+                android:layout_height="150dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@mipmap/ic_launcher" />
+
+            <TextView
+                android:id="@+id/bookTitlePrompt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/booktitle_prompt"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/bookImage" />
+
+            <EditText
+                android:id="@+id/bookTitleEditText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:ems="10"
+                android:hint="@string/booktitle_prompt"
+                android:inputType="text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/bookTitlePrompt" />
+
+            <TextView
+                android:id="@+id/authorPrompt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/bookauthor_prompt"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/bookTitleEditText" />
+
+            <EditText
+                android:id="@+id/authorEditText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:ems="10"
+                android:hint="@string/bookauthor_prompt"
+                android:inputType="textPersonName"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/authorPrompt" />
+
+            <TextView
+                android:id="@+id/isbnPrompt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/bookisbn_prompt"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/authorEditText" />
+
+            <Button
+                android:id="@+id/scanIsbnButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="32dp"
+                android:text="Scan"
+                app:layout_constraintBaseline_toBaselineOf="@+id/isbnEditText"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <EditText
+                android:id="@+id/isbnEditText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:digits="0123456789"
+                android:ems="10"
+                android:hint="@string/bookisbn_prompt"
+                android:inputType="number"
+                app:layout_constraintEnd_toStartOf="@+id/scanIsbnButton"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/isbnPrompt" />
+
+            <Button
+                android:id="@+id/populateFromIsbnBtn"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/populateFromIsbnBtnText"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/isbnEditText" />
+
+            <TextView
+                android:id="@+id/descriptionPrompt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/bookdesc_prompt"
+                app:layout_constraintBottom_toTopOf="@+id/editText4"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/populateFromIsbnBtn" />
+
+            <EditText
+                android:id="@+id/editText4"
+                android:layout_width="0dp"
+                android:layout_height="150dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:ems="10"
+                android:hint="@string/bookdesc_prompt"
+                android:inputType="textMultiLine"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+        </android.support.constraint.ConstraintLayout>
+
+    </ScrollView>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/saveBookBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:clickable="true"
+        app:layout_anchorGravity="bottom|right|end"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@android:drawable/ic_menu_save" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_owner_page.xml
+++ b/app/src/main/res/layout/fragment_owner_page.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="Owner Page Placeholder Text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/menu/nav_drawer_menu.xml
+++ b/app/src/main/res/menu/nav_drawer_menu.xml
@@ -13,6 +13,10 @@
             android:icon="@drawable/ic_account_box_black_24dp"
             android:title="Profile" />
         <item
+            android:id="@+id/nav_addbook"
+            android:icon="@drawable/ic_add_black_24dp"
+            android:title="@string/add_book_prompt" />
+        <item
             android:id="@+id/nav_owner"
             android:icon="@drawable/ic_book_black_24dp"
             android:title="Owner" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,16 @@
     <string name="unknown_error">Unknown error!</string>
     <string name="no_user_signed_in">No user signed in!</string>
     <!-- End of Strings related to login -->
+
+    <!-- Strings for adding/editing books -->
+    <string name="add_book_prompt">Add a Book</string>
+    <string name="edit_book_prompt">Edit Book</string>
+    <string name="bookisbn_prompt">ISBN</string>
+    <string name="populateFromIsbnBtnText">Auto-Populate From ISBN</string>
+    <string name="booktitle_prompt">Title</string>
+    <string name="bookdesc_prompt">Description</string>
+    <string name="bookauthor_prompt">Author</string>
+
+    <string name="action_save">Save</string>
+    <!-- End of Strings for adding/editing books -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_settings">Settings</string>
     <!--Firebase table names-->
     <string name="db_users">users</string>
+    <string name="db_ownerCollection">ownerCollection</string>
     <!--End of Firebase table names-->
     <!-- Strings related to login -->
     <string name="sign_in_cancelled">Canceled Sign-in!</string>
@@ -27,5 +28,6 @@
     <string name="bookauthor_prompt">Author</string>
 
     <string name="action_save">Save</string>
+    <string name="scanBtnPrompt">Scan</string>
     <!-- End of Strings for adding/editing books -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,10 +7,12 @@
     <string name="nav_header_subtitle">android.studio@android.com</string>
     <string name="nav_header_desc">Navigation header</string>
     <string name="action_settings">Settings</string>
+
     <!--Firebase table names-->
     <string name="db_users">users</string>
     <string name="db_ownerCollection">ownerCollection</string>
     <!--End of Firebase table names-->
+
     <!-- Strings related to login -->
     <string name="sign_in_cancelled">Canceled Sign-in!</string>
     <string name="no_internet_connection">No internet connection!</string>
@@ -30,4 +32,8 @@
     <string name="action_save">Save</string>
     <string name="scanBtnPrompt">Scan</string>
     <!-- End of Strings for adding/editing books -->
+
+    <!--Strings for owner page-->
+    <string name="owner_page_title">Owner Page</string>
+    <!--End of Strings for owner page-->
 </resources>


### PR DESCRIPTION
Adding book functionality. 
Does not use ownercollection as it seemed like excessive wrappers to the database that wasn't actually needed if we organize the table properly. 

When someone decides to add a book, the app checks if all the fields are filled. Error prompts not currently implemented for when they are not. If everything is entered, the book is pushed to the database(assuming there is internet connectivity, currently offline adding does not work properly). The book is added under the "ownerCollection" section of the database. Within that, each user with a book will have an entry keyed by userID(generated by signup, not the actual email). Under that then is the list of books they own. 

All added books have by default no borrower and a status of available. 

For right now this is a fragment. However, I would like to make it a separate activity just so people cannot access the nav drawer while inside(as it doesn't make sense to? Should just give them save or cancel as options). Will change to activity when I have time, unless you would prefer this change to be made before merging, in which case i will do so. 

Intended to complete US 01.01.01