### PR TITLE
Enable Offline Persistence

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name="com.example.atheneum.AtheneumFirebaseApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/example/atheneum/AtheneumFirebaseApp.java
+++ b/app/src/main/java/com/example/atheneum/AtheneumFirebaseApp.java
@@ -1,0 +1,19 @@
+package com.example.atheneum;
+
+import com.google.firebase.database.FirebaseDatabase;
+
+/**
+ * Have to extend the base Android application class in order to enable disk persistence
+ *
+ * See: https://stackoverflow.com/a/37766261/11039833
+ */
+public class AtheneumFirebaseApp extends android.app.Application {
+
+        @Override
+        public void onCreate() {
+            super.onCreate();
+            /* Enable disk persistence  */
+            FirebaseDatabase firebaseDatabase = FirebaseDatabase.getInstance();
+            firebaseDatabase.setPersistenceEnabled(true);
+        }
+}


### PR DESCRIPTION
Offline persistence isn't enabled by default, so I'm adding it.

Tested by adding a book to the owner page while offline and then turning on wifi. Verified that the book is added after wifi was back on with the Firebase console.