### PR TITLE
Fix object equals

### DIFF
--- a/app/src/main/java/com/example/atheneum/activities/MainActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/MainActivity.java
@@ -118,7 +118,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         DrawerLayout drawer = (DrawerLayout) findViewById(R.id.drawer_layout);
         if (drawer.isDrawerOpen(GravityCompat.START)) {
             drawer.closeDrawer(GravityCompat.START);
-        } else if (tag == "Home") {
+        } else if (tag.equals("Home")) {
             Log.d(TAG, "Prevented removing home frag");
             return;
         } else if (count > 0) {


### PR DESCRIPTION
Replace == with obj.equals() when matching a string since that can cause subtly broken behaviour in java since java compares the address of the object with == but .equals() actually compares the attributes of the object (which is what we want in this case).