### PR TITLE
Added UI Tests for SignIn Using Espresso

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Atheneum
+
+A decentralized, peer-to-peer library.
+
+Atheneum (derived from Athenaeum)
+_noun_
+1. an institution for the promotion of literary or scientific learning.
+2. a library or reading room.
+3. ( initial capital letter ) a sanctuary of Athena at Athens, built by the Roman emperor Hadrian, and frequented by poets and scholars. 
+
+
+## Running UI Tests
+
+To run the UI Tests go to C:\Users\ishaa\Projects\Atheneum\app\src\androidTest\java\com\example\atheneum\activities\AtheneumTestSuite.java
+in Android Studio and click run.
+
+Do not try to run the tests outside of the test suite since the tests require a test user to be
+loggedin. Running the test suite ensures that the tests are run in order.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,8 +36,10 @@ dependencies {
     implementation 'com.firebaseui:firebase-ui-auth:4.3.1'
     implementation 'com.android.support:support-v4:28.0.0'
     testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-intents:3.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
     // required if you want to use Mockito for unit tests
     testImplementation 'org.mockito:mockito-core:2.7.22'
     // required if you want to use Mockito for Android tests

--- a/app/src/androidTest/java/com/example/atheneum/activities/AtheneumTestSuite.java
+++ b/app/src/androidTest/java/com/example/atheneum/activities/AtheneumTestSuite.java
@@ -1,0 +1,20 @@
+package com.example.atheneum.activities;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+       SignInTest.class,
+       SignOutTest.class,
+})
+/**
+ * Class that runs all the UI tests in the proper order.
+ *
+ * Add any classes that test main functionality between the SignIn and SignOut classes inside of the
+ * annotation.
+ */
+public class AtheneumTestSuite {
+    // the class remains empty,
+    // used only as a holder for the above annotations
+}

--- a/app/src/androidTest/java/com/example/atheneum/activities/FirebaseUIAuthActivitySignInTest.java
+++ b/app/src/androidTest/java/com/example/atheneum/activities/FirebaseUIAuthActivitySignInTest.java
@@ -10,6 +10,8 @@ import android.view.ViewGroup;
 import android.view.ViewParent;
 
 import com.example.atheneum.R;
+import com.example.atheneum.utils.ConnectionChecker;
+import com.example.atheneum.utils.FirebaseAuthUtils;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -19,6 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static android.support.test.InstrumentationRegistry.getContext;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
@@ -30,6 +33,8 @@ import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
 import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.is;
 
@@ -42,6 +47,12 @@ public class FirebaseUIAuthActivitySignInTest {
 
     @Test
     public void firebaseUIAuthActivitySignInTest() {
+
+        assertFalse("Sign out of the app before trying to run this test!", FirebaseAuthUtils.isCurrentUserAuthenticated());
+
+        ConnectionChecker connectionChecker = new ConnectionChecker(getContext());
+        assertTrue("Sign-in tests requires network connectivity!", connectionChecker.isNetworkConnected());
+
         // Added a sleep statement to match the app's execution delay.
         // The recommended way to handle such scenarios is to use Espresso idling resources:
         // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html

--- a/app/src/androidTest/java/com/example/atheneum/activities/FirebaseUIAuthActivitySignInTest.java
+++ b/app/src/androidTest/java/com/example/atheneum/activities/FirebaseUIAuthActivitySignInTest.java
@@ -1,0 +1,238 @@
+package com.example.atheneum.activities;
+
+
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import com.example.atheneum.R;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.action.ViewActions.scrollTo;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class FirebaseUIAuthActivitySignInTest {
+
+    @Rule
+    public ActivityTestRule<FirebaseUIAuthActivity> mActivityTestRule = new ActivityTestRule<>(FirebaseUIAuthActivity.class);
+
+    @Test
+    public void firebaseUIAuthActivitySignInTest() {
+        // Added a sleep statement to match the app's execution delay.
+        // The recommended way to handle such scenarios is to use Espresso idling resources:
+        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        ViewInteraction textView = onView(
+                allOf(withText("Sign in"),
+                        childAtPosition(
+                                allOf(withId(R.id.action_bar),
+                                        childAtPosition(
+                                                withId(R.id.action_bar_container),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        textView.check(matches(withText("Sign in")));
+
+        // Added a sleep statement to match the app's execution delay.
+        // The recommended way to handle such scenarios is to use Espresso idling resources:
+        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        ViewInteraction textInputEditText = onView(
+                allOf(withId(R.id.email),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.email_layout),
+                                        0),
+                                0)));
+        textInputEditText.perform(scrollTo(), click());
+
+        ViewInteraction textInputEditText2 = onView(
+                allOf(withId(R.id.email),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.email_layout),
+                                        0),
+                                0)));
+        textInputEditText2.perform(scrollTo(), replaceText("logintester@firebase.com"), closeSoftKeyboard());
+
+        ViewInteraction appCompatButton = onView(
+                allOf(withId(R.id.button_next), withText("Next"),
+                        childAtPosition(
+                                allOf(withId(R.id.email_top_layout),
+                                        childAtPosition(
+                                                withClassName(is("android.widget.ScrollView")),
+                                                0)),
+                                2)));
+        appCompatButton.perform(scrollTo(), click());
+
+        // Added a sleep statement to match the app's execution delay.
+        // The recommended way to handle such scenarios is to use Espresso idling resources:
+        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        ViewInteraction textView2 = onView(
+                allOf(withText("Sign in"),
+                        childAtPosition(
+                                allOf(withId(R.id.action_bar),
+                                        childAtPosition(
+                                                withId(R.id.action_bar_container),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        textView2.check(matches(withText("Sign in")));
+
+        ViewInteraction textView3 = onView(
+                allOf(withId(R.id.heading), withText("Welcome back!"),
+                        childAtPosition(
+                                childAtPosition(
+                                        IsInstanceOf.<View>instanceOf(android.widget.ScrollView.class),
+                                        0),
+                                0),
+                        isDisplayed()));
+        textView3.check(matches(withText("Welcome back!")));
+
+        ViewInteraction textInputEditText3 = onView(
+                allOf(withId(R.id.password),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.password_layout),
+                                        0),
+                                0)));
+        textInputEditText3.perform(scrollTo(), click());
+
+        ViewInteraction textInputEditText4 = onView(
+                allOf(withId(R.id.password),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.password_layout),
+                                        0),
+                                0)));
+        textInputEditText4.perform(scrollTo(), replaceText("logintester1"), closeSoftKeyboard());
+
+        ViewInteraction appCompatButton2 = onView(
+                allOf(withId(R.id.button_done), withText("Sign in"),
+                        childAtPosition(
+                                childAtPosition(
+                                        withClassName(is("android.widget.ScrollView")),
+                                        0),
+                                4)));
+        appCompatButton2.perform(scrollTo(), click());
+
+        // Added a sleep statement to match the app's execution delay.
+        // The recommended way to handle such scenarios is to use Espresso idling resources:
+        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        ViewInteraction appCompatImageButton = onView(
+                allOf(withContentDescription("Open navigation drawer"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withClassName(is("android.support.design.widget.AppBarLayout")),
+                                                0)),
+                                1),
+                        isDisplayed()));
+        appCompatImageButton.perform(click());
+
+        ViewInteraction textView5 = onView(
+                allOf(withId(R.id.nav_user_name), withText("logintester@firebase.com"),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.navigation_header_container),
+                                        0),
+                                1),
+                        isDisplayed()));
+        textView5.check(matches(withText("logintester@firebase.com")));
+
+        ViewInteraction navigationMenuItemView = onView(
+                allOf(childAtPosition(
+                        allOf(withId(R.id.design_navigation_view),
+                                childAtPosition(
+                                        withId(R.id.nav_view),
+                                        0)),
+                        6),
+                        isDisplayed()));
+        navigationMenuItemView.perform(click());
+
+        // Added a sleep statement to match the app's execution delay.
+        // The recommended way to handle such scenarios is to use Espresso idling resources:
+        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        ViewInteraction textView6 = onView(
+                allOf(withText("Sign in"),
+                        childAtPosition(
+                                allOf(withId(R.id.action_bar),
+                                        childAtPosition(
+                                                withId(R.id.action_bar_container),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        textView6.check(matches(withText("Sign in")));
+    }
+
+    private static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/app/src/androidTest/java/com/example/atheneum/activities/SignInTest.java
+++ b/app/src/androidTest/java/com/example/atheneum/activities/SignInTest.java
@@ -40,14 +40,17 @@ import static org.hamcrest.Matchers.is;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
-public class FirebaseUIAuthActivitySignInTest {
+/**
+ * Tests login functionality. Requires that the user is signed out and that internet is on.
+ */
+public class SignInTest {
+    private static long DELAY_MS = 500;
 
     @Rule
     public ActivityTestRule<FirebaseUIAuthActivity> mActivityTestRule = new ActivityTestRule<>(FirebaseUIAuthActivity.class);
 
     @Test
-    public void firebaseUIAuthActivitySignInTest() {
-
+    public void signInTest() {
         assertFalse("Sign out of the app before trying to run this test!", FirebaseAuthUtils.isCurrentUserAuthenticated());
 
         ConnectionChecker connectionChecker = new ConnectionChecker(getContext());
@@ -57,7 +60,7 @@ public class FirebaseUIAuthActivitySignInTest {
         // The recommended way to handle such scenarios is to use Espresso idling resources:
         // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
         try {
-            Thread.sleep(500);
+            Thread.sleep(DELAY_MS);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -73,15 +76,6 @@ public class FirebaseUIAuthActivitySignInTest {
                         isDisplayed()));
         textView.check(matches(withText("Sign in")));
 
-        // Added a sleep statement to match the app's execution delay.
-        // The recommended way to handle such scenarios is to use Espresso idling resources:
-        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-
         ViewInteraction textInputEditText = onView(
                 allOf(withId(R.id.email),
                         childAtPosition(
@@ -89,16 +83,7 @@ public class FirebaseUIAuthActivitySignInTest {
                                         withId(R.id.email_layout),
                                         0),
                                 0)));
-        textInputEditText.perform(scrollTo(), click());
-
-        ViewInteraction textInputEditText2 = onView(
-                allOf(withId(R.id.email),
-                        childAtPosition(
-                                childAtPosition(
-                                        withId(R.id.email_layout),
-                                        0),
-                                0)));
-        textInputEditText2.perform(scrollTo(), replaceText("logintester@firebase.com"), closeSoftKeyboard());
+        textInputEditText.perform(scrollTo(), replaceText("logintester@firebase.com"), closeSoftKeyboard());
 
         ViewInteraction appCompatButton = onView(
                 allOf(withId(R.id.button_next), withText("Next"),
@@ -114,7 +99,7 @@ public class FirebaseUIAuthActivitySignInTest {
         // The recommended way to handle such scenarios is to use Espresso idling resources:
         // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
         try {
-            Thread.sleep(500);
+            Thread.sleep(DELAY_MS);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -140,23 +125,14 @@ public class FirebaseUIAuthActivitySignInTest {
                         isDisplayed()));
         textView3.check(matches(withText("Welcome back!")));
 
-        ViewInteraction textInputEditText3 = onView(
+        ViewInteraction textInputEditText2 = onView(
                 allOf(withId(R.id.password),
                         childAtPosition(
                                 childAtPosition(
                                         withId(R.id.password_layout),
                                         0),
                                 0)));
-        textInputEditText3.perform(scrollTo(), click());
-
-        ViewInteraction textInputEditText4 = onView(
-                allOf(withId(R.id.password),
-                        childAtPosition(
-                                childAtPosition(
-                                        withId(R.id.password_layout),
-                                        0),
-                                0)));
-        textInputEditText4.perform(scrollTo(), replaceText("logintester1"), closeSoftKeyboard());
+        textInputEditText2.perform(scrollTo(), replaceText("logintester1"), closeSoftKeyboard());
 
         ViewInteraction appCompatButton2 = onView(
                 allOf(withId(R.id.button_done), withText("Sign in"),
@@ -171,7 +147,7 @@ public class FirebaseUIAuthActivitySignInTest {
         // The recommended way to handle such scenarios is to use Espresso idling resources:
         // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
         try {
-            Thread.sleep(500);
+            Thread.sleep(DELAY_MS);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -187,7 +163,7 @@ public class FirebaseUIAuthActivitySignInTest {
                         isDisplayed()));
         appCompatImageButton.perform(click());
 
-        ViewInteraction textView5 = onView(
+        ViewInteraction textView4 = onView(
                 allOf(withId(R.id.nav_user_name), withText("logintester@firebase.com"),
                         childAtPosition(
                                 childAtPosition(
@@ -195,37 +171,7 @@ public class FirebaseUIAuthActivitySignInTest {
                                         0),
                                 1),
                         isDisplayed()));
-        textView5.check(matches(withText("logintester@firebase.com")));
-
-        ViewInteraction navigationMenuItemView = onView(
-                allOf(childAtPosition(
-                        allOf(withId(R.id.design_navigation_view),
-                                childAtPosition(
-                                        withId(R.id.nav_view),
-                                        0)),
-                        6),
-                        isDisplayed()));
-        navigationMenuItemView.perform(click());
-
-        // Added a sleep statement to match the app's execution delay.
-        // The recommended way to handle such scenarios is to use Espresso idling resources:
-        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-
-        ViewInteraction textView6 = onView(
-                allOf(withText("Sign in"),
-                        childAtPosition(
-                                allOf(withId(R.id.action_bar),
-                                        childAtPosition(
-                                                withId(R.id.action_bar_container),
-                                                0)),
-                                0),
-                        isDisplayed()));
-        textView6.check(matches(withText("Sign in")));
+        textView4.check(matches(withText("logintester@firebase.com")));
     }
 
     private static Matcher<View> childAtPosition(

--- a/app/src/androidTest/java/com/example/atheneum/activities/SignOutTest.java
+++ b/app/src/androidTest/java/com/example/atheneum/activities/SignOutTest.java
@@ -1,0 +1,122 @@
+package com.example.atheneum.activities;
+
+
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import com.example.atheneum.R;
+import com.example.atheneum.utils.FirebaseAuthUtils;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.action.ViewActions.scrollTo;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+/**
+ * Signs out user from the app. Requires the user to be signed in first.
+ */
+public class SignOutTest {
+    private static final long DELAY_MS = 500;
+
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
+
+    @Test
+    public void firebaseUIAuthActivityTest() {
+        assertTrue("Must be logged in before trying to logout!", FirebaseAuthUtils.isCurrentUserAuthenticated());
+
+        // Added a sleep statement to match the app's execution delay.
+        // The recommended way to handle such scenarios is to use Espresso idling resources:
+        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
+        try {
+            Thread.sleep(DELAY_MS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        ViewInteraction appCompatImageButton = onView(
+                allOf(withContentDescription("Open navigation drawer"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withClassName(is("android.support.design.widget.AppBarLayout")),
+                                                0)),
+                                1),
+                        isDisplayed()));
+        appCompatImageButton.perform(click());
+
+        ViewInteraction navigationMenuItemView = onView(
+                allOf(childAtPosition(
+                        allOf(withId(R.id.design_navigation_view),
+                                childAtPosition(
+                                        withId(R.id.nav_view),
+                                        0)),
+                        6),
+                        isDisplayed()));
+        navigationMenuItemView.perform(click());
+
+        // Added a sleep statement to match the app's execution delay.
+        // The recommended way to handle such scenarios is to use Espresso idling resources:
+        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
+        try {
+            Thread.sleep(DELAY_MS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        ViewInteraction textView = onView(
+                allOf(withText("Sign in"),
+                        childAtPosition(
+                                allOf(withId(R.id.action_bar),
+                                        childAtPosition(
+                                                withId(R.id.action_bar_container),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        textView.check(matches(withText("Sign in")));
+    }
+
+    private static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/app/src/main/java/com/example/atheneum/activities/FirebaseUIAuthActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/FirebaseUIAuthActivity.java
@@ -115,7 +115,7 @@ public class FirebaseUIAuthActivity extends AppCompatActivity {
                 AuthUI.getInstance()
                         .createSignInIntentBuilder()
                         .setAvailableProviders(providers)
-//                                        .setIsSmartLockEnabled(false) // Disabled for testing, used for password-less login
+                        .setIsSmartLockEnabled(false) // Used for password-less login, disabled to make UI tests easy
                         .build(),
                 AUTH_RC_CODE);
     }


### PR DESCRIPTION
Added UI tests for signin using Espresso.

Signup UI tests were left out since that requires UI in the app to delete an account in order for the tests to be repeatable. That can come in a separate PR. However, the danger with having the user being able to delete the account is that they normally shouldn't be able to do that since that could really mess up with the database since a lot of stuff is tied in with their userID.