### PR TITLE
Fix inputless fields for add book and limit isbn field to 13 characters

### DIFF
--- a/app/src/main/java/com/example/atheneum/activities/AddEditBookActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/AddEditBookActivity.java
@@ -97,6 +97,7 @@ public class AddEditBookActivity extends AppCompatActivity {
 
 
         this.view = findViewById(android.R.id.content);
+        context = this.getApplicationContext();
 
         // bind editText references to UI elements
         titleEditText = findViewById(R.id.bookTitleEditText);

--- a/app/src/main/res/layout/activity_add_book.xml
+++ b/app/src/main/res/layout/activity_add_book.xml
@@ -106,6 +106,7 @@
                 android:ems="10"
                 android:hint="@string/bookisbn_prompt"
                 android:inputType="number"
+                android:maxLength="13"
                 app:layout_constraintEnd_toStartOf="@+id/scanIsbnButton"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Closes #122 and #123 

Fix application crash bug by defining context and setting the length limit for the isbn field in xml file.