### PR TITLE
Accept/decline requests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'recyclerview-v7'
     }
     implementation 'com.jayway.android.robotium:robotium-solo:5.6.3'
+    implementation 'org.jetbrains:annotations-java5:15.0'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
+        <service android:name=".services.NotificationsService"></service>
         <activity
             android:name=".activities.EditProfileActivity"
             android:label="@string/title_activity_edit_profile"

--- a/app/src/main/java/com/example/atheneum/activities/BookInfoActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/BookInfoActivity.java
@@ -284,6 +284,7 @@ public class BookInfoActivity extends AppCompatActivity {
             requestsLayoutManager = new LinearLayoutManager(this);
             requestsRecyclerView.setLayoutManager(requestsLayoutManager);
             requestsRecyclerView.setAdapter(firebaseRecyclerAdapter);
+            requestsRecyclerView.setNestedScrollingEnabled(false);
             requestsRecyclerView.addItemDecoration(new DividerItemDecoration(requestsRecyclerView.getContext(),
                     DividerItemDecoration.VERTICAL));
         }

--- a/app/src/main/java/com/example/atheneum/activities/FirebaseUIAuthActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/FirebaseUIAuthActivity.java
@@ -58,51 +58,7 @@ public class FirebaseUIAuthActivity extends AppCompatActivity {
         finish();
     }
 
-    /**
-     *
-     * See: https://www.androidauthority.com/android-push-notifications-with-firebase-cloud-messaging-925075/
-     */
     private void postSignInTransition() {
-        //store user's device token in datbase
-        final FirebaseUser firebaseUser = FirebaseAuth.getInstance().getCurrentUser();
-        final FirebaseDatabase db = FirebaseDatabase.getInstance();
-        DatabaseReference ref = db.getReference().child("userDeviceTokens")
-            .child(firebaseUser.getUid());
-
-        ref.addListenerForSingleValueEvent(new ValueEventListener() {
-            @Override
-            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-                // Add user information to user table if the user doesn't exist in
-                // our database
-                User newUser = new User(firebaseUser.getUid(), firebaseUser.getEmail());
-                final DatabaseReference userTokensRef = db.getReference().child("userDeviceTokens")
-                        .child(newUser.getUserID());
-
-                FirebaseInstanceId.getInstance().getInstanceId()
-                        .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
-                            @Override
-                            public void onComplete(@NonNull Task<InstanceIdResult> task) {
-                                if (!task.isSuccessful()) {
-                                    Log.i(TAG, "cannot store user device token?!");
-                                    return;
-                                }
-
-                                String token = task.getResult().getToken();
-                                Log.d(TAG, token);
-
-                                //Store user's instanceID token in firebase
-                                userTokensRef.setValue(token);
-                                Log.i(TAG, "User device token stored in database");
-                            }
-                        });
-            }
-
-            @Override
-            public void onCancelled(@NonNull DatabaseError databaseError) {
-                Log.i(TAG, "user device token cannot be stored??");
-            }
-        });
-
         Intent intent = new Intent(getApplicationContext(), MainActivity.class);
         startActivity(intent);
         finish();

--- a/app/src/main/java/com/example/atheneum/activities/MainActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/MainActivity.java
@@ -37,6 +37,7 @@ import com.example.atheneum.fragments.SearchFragment;
 import com.example.atheneum.models.Book;
 import com.example.atheneum.models.Notification;
 import com.example.atheneum.models.User;
+import com.example.atheneum.services.NotificationsService;
 import com.example.atheneum.utils.FirebaseAuthUtils;
 import com.example.atheneum.utils.PhotoUtils;
 import com.example.atheneum.viewmodels.FirebaseRefUtils.BooksRefUtils;
@@ -65,12 +66,7 @@ import java.util.ArrayList;
  *
  */
 public class MainActivity extends AppCompatActivity implements NavigationView.OnNavigationItemSelectedListener {
-    private UserNotificationsViewModel userNotificationsViewModel;
-    private LiveData<Notification> notificationLiveData;
-    private Observer<Notification> notificationObserver;
-
     private String TAG = MainActivity.class.getSimpleName();
-    private int pushNotificationID = 0;
 
 //    @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -120,42 +116,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 }
             });
 
-            //notifications
-            UserNotificationsViewModelFactory userNotificationsViewModelFactory =
-                    new UserNotificationsViewModelFactory(firebaseUser.getUid());
-            userNotificationsViewModel = ViewModelProviders
-                    .of(this, userNotificationsViewModelFactory)
-                    .get(UserNotificationsViewModel.class);
-            notificationLiveData = userNotificationsViewModel.getNotificationLiveData();
-            notificationObserver = new Observer<Notification>() {
-                @Override
-                public void onChanged(@Nullable Notification notification) {
-                    if (notification == null) {
-                        Log.i(TAG, "notification is null");
-                    } else {
-                        sendNotification(notification.getMessage());
-                        DatabaseWriteHelper.deleteNotification(notification);
-                    }
-                }
-            };
-            notificationLiveData.observeForever(notificationObserver);
+            // start service for receiving notifications throughout app
+            // https://stackoverflow.com/a/27842496
+            Intent service = new Intent(this.getApplicationContext(), NotificationsService.class);
+            startService(service);
         } else {
             Log.w(TAG, "Shouldn't happen!");
         }
-
-    }
-
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        notificationLiveData.removeObserver(notificationObserver);
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        notificationLiveData.removeObserver(notificationObserver);
     }
 
     /**
@@ -225,7 +192,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             fragmentManager.beginTransaction().replace(R.id.content_frame, new SearchFragment()).addToBackStack("Search").commit();
 
         } else if (id == R.id.nav_logout) {
-            notificationLiveData.removeObserver(notificationObserver);
+            Log.i(TAG, "logging out");
+            Intent service = new Intent(this.getApplicationContext(), NotificationsService.class);
+            stopService(service);
             // Sign out of account and go back to authentication screen
             AuthUI.getInstance()
                     .signOut(this)
@@ -264,44 +233,5 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         Intent view_profile_intent = new Intent(this, ViewProfileActivity.class);
         view_profile_intent.putExtra("user", user);
         startActivity(view_profile_intent);
-    }
-
-    /**
-     * Construct and send notification to app. user's phone
-     * See: https://developer.android.com/guide/topics/ui/notifiers/notifications
-     * See: https://developer.android.com/training/notify-user/build-notification
-     * See: https://developer.android.com/training/notify-user/expanded
-     *
-     * @param notificationMessage
-     */
-    public void sendNotification(String notificationMessage) {
-        Intent intent = new Intent(getBaseContext(), MainActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-
-        String channelId = getString(R.string.profile_title);
-        Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
-        NotificationCompat.Builder notificationBuilder =
-                new NotificationCompat.Builder(getBaseContext(), channelId)
-                        .setSmallIcon(R.drawable.ic_book_black_24dp)
-                        .setContentTitle(getString(R.string.app_name))
-                        .setContentText(notificationMessage)
-                        .setStyle(new NotificationCompat.BigTextStyle()
-                                .bigText(notificationMessage))
-                        .setAutoCancel(true)
-                        .setSound(defaultSoundUri);
-
-        NotificationManager notificationManager =
-                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-
-        // Since android Oreo notification channel is needed.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel channel = new NotificationChannel(channelId,
-                    "Channel human readable title",
-                    NotificationManager.IMPORTANCE_DEFAULT);
-            notificationManager.createNotificationChannel(channel);
-        }
-
-        notificationManager.notify(pushNotificationID, notificationBuilder.build());
-        pushNotificationID++;
     }
 }

--- a/app/src/main/java/com/example/atheneum/activities/MainActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/MainActivity.java
@@ -193,6 +193,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
         } else if (id == R.id.nav_logout) {
             Log.i(TAG, "logging out");
+            // stop notifications service
             Intent service = new Intent(this.getApplicationContext(), NotificationsService.class);
             stopService(service);
             // Sign out of account and go back to authentication screen

--- a/app/src/main/java/com/example/atheneum/models/Notification.java
+++ b/app/src/main/java/com/example/atheneum/models/Notification.java
@@ -25,7 +25,11 @@ public class Notification {
         /**
          * Request notification type.
          */
-        REQUEST
+        REQUEST,
+        /**
+         * Decline notification type.
+         */
+        DECLINE
     }
 
     /**
@@ -199,6 +203,8 @@ public class Notification {
             this.message = userName + " has requested for your book: " + bookName;
         } else if (this.rNotificationType == NotificationType.ACCEPT) {
             this.message = userName + " has accepted your request for the book " + bookName;
+        } else if (this.rNotificationType == NotificationType.DECLINE) {
+            this.message = userName + " has declined your request for the book " + bookName;
         }
     }
 }

--- a/app/src/main/java/com/example/atheneum/services/NotificationsService.java
+++ b/app/src/main/java/com/example/atheneum/services/NotificationsService.java
@@ -1,0 +1,160 @@
+package com.example.atheneum.services;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.Observer;
+import android.arch.lifecycle.ViewModelProviders;
+import android.content.Context;
+import android.content.Intent;
+import android.media.RingtoneManager;
+import android.net.Uri;
+import android.os.Build;
+import android.os.IBinder;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.NotificationCompat;
+import android.util.Log;
+
+import com.example.atheneum.R;
+import com.example.atheneum.activities.MainActivity;
+import com.example.atheneum.models.Notification;
+import com.example.atheneum.utils.FirebaseAuthUtils;
+import com.example.atheneum.viewmodels.FirebaseRefUtils.DatabaseWriteHelper;
+import com.example.atheneum.viewmodels.FirebaseRefUtils.NotificationsRefUtils;
+import com.example.atheneum.viewmodels.UserNotificationsViewModel;
+import com.example.atheneum.viewmodels.UserNotificationsViewModelFactory;
+import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.database.ChildEventListener;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+
+/**
+ * A service to run indefinitely for push notifications
+ * See: https://developer.android.com/guide/components/services
+ */
+public class NotificationsService extends Service {
+    public static DatabaseReference notificationsRef = null;
+    public static ChildEventListener notificationListener = null;
+
+    private int pushNotificationID = 0;
+
+    private final static String TAG = NotificationsService.class.getSimpleName();
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    /**
+     * Start listening for notifications in DB
+     *
+     * @param intent
+     * @param flags
+     * @param startId
+     * @return
+     */
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        Log.i(TAG, "starting");
+        //notifications
+        if (FirebaseAuthUtils.isCurrentUserAuthenticated()
+                && notificationsRef == null
+                && notificationListener == null) {
+            Log.i(TAG, "starting listener");
+            FirebaseUser firebaseUser = FirebaseAuthUtils.getCurrentUser();
+            notificationsRef = NotificationsRefUtils
+                    .getNotificationsRef(firebaseUser.getUid());
+            notificationListener = new ChildEventListener() {
+                @Override
+                public void onChildAdded(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+                    Notification notification = dataSnapshot.getValue(Notification.class);
+                    sendNotification(notification.getMessage());
+                    DatabaseWriteHelper.deleteNotification(notification);
+                }
+
+                @Override
+                public void onChildChanged(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+
+                }
+
+                @Override
+                public void onChildRemoved(@NonNull DataSnapshot dataSnapshot) {
+
+                }
+
+                @Override
+                public void onChildMoved(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+
+                }
+
+                @Override
+                public void onCancelled(@NonNull DatabaseError databaseError) {
+
+                }
+            };
+            notificationsRef.addChildEventListener(notificationListener);
+        }
+        return super.onStartCommand(intent, flags, startId);
+    }
+
+    @Override
+    public boolean stopService(Intent name) {
+        Log.i(TAG, "stopping");
+        return super.stopService(name);
+    }
+
+    /**
+     * Stop listening for notifications in DB
+     */
+    @Override
+    public void onDestroy() {
+        Log.i(TAG, "destroying");
+        notificationsRef.removeEventListener(notificationListener);
+        notificationsRef = null;
+        notificationListener = null;
+        super.onDestroy();
+    }
+
+    /**
+     * Construct and send notification to app. user's phone
+     * See: https://developer.android.com/guide/topics/ui/notifiers/notifications
+     * See: https://developer.android.com/training/notify-user/build-notification
+     * See: https://developer.android.com/training/notify-user/expanded
+     *
+     * @param notificationMessage
+     */
+    private void sendNotification(String notificationMessage) {
+        Intent intent = new Intent(getBaseContext(), MainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
+        String channelId = getString(R.string.profile_title);
+        Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+        NotificationCompat.Builder notificationBuilder =
+                new NotificationCompat.Builder(getBaseContext(), channelId)
+                        .setSmallIcon(R.drawable.ic_book_black_24dp)
+                        .setContentTitle(getString(R.string.app_name))
+                        .setContentText(notificationMessage)
+                        .setStyle(new NotificationCompat.BigTextStyle()
+                                .bigText(notificationMessage))
+                        .setAutoCancel(true)
+                        .setSound(defaultSoundUri);
+
+        NotificationManager notificationManager =
+                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+        // Since android Oreo notification channel is needed.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(channelId,
+                    "Channel human readable title",
+                    NotificationManager.IMPORTANCE_DEFAULT);
+            notificationManager.createNotificationChannel(channel);
+        }
+
+        notificationManager.notify(pushNotificationID, notificationBuilder.build());
+        pushNotificationID++;
+    }
+}

--- a/app/src/main/java/com/example/atheneum/utils/BookRequestViewHolder.java
+++ b/app/src/main/java/com/example/atheneum/utils/BookRequestViewHolder.java
@@ -3,6 +3,7 @@ package com.example.atheneum.utils;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -17,10 +18,14 @@ import com.example.atheneum.activities.BookInfoActivity;
 public class BookRequestViewHolder extends RecyclerView.ViewHolder {
     public LinearLayout requestItem;
     public TextView requesterNameTextView;
+    public ImageView declineRequestImageView;
+    public ImageView acceptRequestImageView;
 
     public BookRequestViewHolder(@NonNull View bookView) {
         super(bookView);
         requestItem = (LinearLayout) bookView.findViewById(R.id.request_on_book_card);
         requesterNameTextView = (TextView) bookView.findViewById(R.id.requester_name);
+        declineRequestImageView = (ImageView) bookView.findViewById(R.id.request_decline);
+        acceptRequestImageView = (ImageView) bookView.findViewById(R.id.request_accept);
     }
 }

--- a/app/src/main/java/com/example/atheneum/viewmodels/FirebaseRefUtils/DatabaseWriteHelper.java
+++ b/app/src/main/java/com/example/atheneum/viewmodels/FirebaseRefUtils/DatabaseWriteHelper.java
@@ -8,8 +8,11 @@ import com.example.atheneum.models.Book;
 import com.example.atheneum.models.Notification;
 import com.example.atheneum.models.Request;
 import com.example.atheneum.models.User;
+import com.google.firebase.database.ChildEventListener;
+import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.ValueEventListener;
 
 import java.util.HashMap;
 
@@ -104,18 +107,28 @@ public class DatabaseWriteHelper {
         });
     }
 
-    public static void acceptRequest(Request request) {
+    public static void acceptRequest(final Request request,
+                                     Notification acceptNotification,
+                                     final Notification declineNotification) {
         HashMap<String, Object> updates = new HashMap<String, Object>();
 
         final String requesterRef = String.format("requestCollection/%s/%s",
-                request.getRequesterID(), request.getBookID());
-        final String bookRequestRef = String.format("bookRequests/%s",
+                request.getRequesterID(),
                 request.getBookID());
-        final String bookRef = String.format("books/%s/status", request.getBookID());
+        final String bookRequestRef = String.format("bookRequests/%s/%s",
+                request.getBookID(),
+                request.getRequesterID());
+        final String bookBorrowerIDRef = String.format("books/%s/borrowerID",
+                request.getBookID());
+        final String bookStatusRef = String.format("books/%s/status", request.getBookID());
+        final String notificationsRef = String.format("notifications/%s/%s",
+                acceptNotification.getNotificationReceiverID(),
+                acceptNotification.getNotificationID());
 
-        updates.put(requesterRef, request);
-        updates.put(bookRequestRef, request.getRequesterID());
-        updates.put(bookRef, Book.Status.ACCEPTED.toString());
+        updates.put(requesterRef, null);
+        updates.put(bookRequestRef, null);
+        updates.put(bookBorrowerIDRef, request.getRequesterID());
+        updates.put(bookStatusRef, Book.Status.ACCEPTED.toString());
 
         RootRefUtils.ROOT_REF.updateChildren(updates, new DatabaseReference.CompletionListener() {
             @Override
@@ -124,10 +137,46 @@ public class DatabaseWriteHelper {
                     Log.w(TAG, "Error updating data at " + databaseReference.toString());
                     Log.i(TAG, "bookRequestRef: " + bookRequestRef.toString());
                     Log.i(TAG, "requesterRef: " + requesterRef.toString());
-                    Log.i(TAG, "bookRef: " + bookRef.toString());
+                    Log.i(TAG, "bookBorrowerIDRef: " + bookBorrowerIDRef.toString());
+                    Log.i(TAG, "bookStatusRef: " + bookStatusRef);
+                    Log.i(TAG, "notificationsRef: " + notificationsRef);
                 } else {
                     Log.i(TAG, "Successful update at " + databaseReference.toString());
+                    declineAllRequests(request.getBookID(), declineNotification);
                 }
+            }
+        });
+    }
+
+    public static void declineAllRequests(final String bookID, final Notification notification) {
+        DatabaseReference bookRequestRef = RequestCollectionRefUtils
+                .getBookRequestCollectionRef(bookID);
+        bookRequestRef.addChildEventListener(new ChildEventListener() {
+            @Override
+            public void onChildAdded(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+                final String requesterID = dataSnapshot.getKey();
+                Log.i(TAG, "requester being declined from book acceptance" + requesterID);
+                declineRequest(requesterID, bookID, notification);
+            }
+
+            @Override
+            public void onChildChanged(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+
+            }
+
+            @Override
+            public void onChildRemoved(@NonNull DataSnapshot dataSnapshot) {
+
+            }
+
+            @Override
+            public void onChildMoved(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+
+            }
+
+            @Override
+            public void onCancelled(@NonNull DatabaseError databaseError) {
+
             }
         });
     }

--- a/app/src/main/java/com/example/atheneum/viewmodels/FirebaseRefUtils/DatabaseWriteHelper.java
+++ b/app/src/main/java/com/example/atheneum/viewmodels/FirebaseRefUtils/DatabaseWriteHelper.java
@@ -125,7 +125,7 @@ public class DatabaseWriteHelper {
                 acceptNotification.getNotificationReceiverID(),
                 acceptNotification.getNotificationID());
 
-        updates.put(requesterRef, null);
+        updates.put(requesterRef, request);
         updates.put(bookRequestRef, null);
         updates.put(bookBorrowerIDRef, request.getRequesterID());
         updates.put(bookStatusRef, Book.Status.ACCEPTED.toString());
@@ -156,9 +156,10 @@ public class DatabaseWriteHelper {
             @Override
             public void onChildAdded(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
                 final String requesterID = dataSnapshot.getKey();
-                Log.i(TAG, "requester being declined from book acceptance" + requesterID);
+                Log.i(TAG, "requester being declined from book acceptance: " + requesterID);
                 notification.setNotificationReceiverID(requesterID);
                 notification.setRequesterID(requesterID);
+                Log.i(TAG, "notification requester ID: " + notification.getRequesterID());
                 declineRequest(requesterID, bookID, notification);
             }
 

--- a/app/src/main/java/com/example/atheneum/viewmodels/FirebaseRefUtils/DatabaseWriteHelper.java
+++ b/app/src/main/java/com/example/atheneum/viewmodels/FirebaseRefUtils/DatabaseWriteHelper.java
@@ -129,6 +129,7 @@ public class DatabaseWriteHelper {
         updates.put(bookRequestRef, null);
         updates.put(bookBorrowerIDRef, request.getRequesterID());
         updates.put(bookStatusRef, Book.Status.ACCEPTED.toString());
+        updates.put(notificationsRef, acceptNotification);
 
         RootRefUtils.ROOT_REF.updateChildren(updates, new DatabaseReference.CompletionListener() {
             @Override
@@ -156,6 +157,8 @@ public class DatabaseWriteHelper {
             public void onChildAdded(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
                 final String requesterID = dataSnapshot.getKey();
                 Log.i(TAG, "requester being declined from book acceptance" + requesterID);
+                notification.setNotificationReceiverID(requesterID);
+                notification.setRequesterID(requesterID);
                 declineRequest(requesterID, bookID, notification);
             }
 

--- a/app/src/main/java/com/example/atheneum/viewmodels/FirebaseRefUtils/DatabaseWriteHelper.java
+++ b/app/src/main/java/com/example/atheneum/viewmodels/FirebaseRefUtils/DatabaseWriteHelper.java
@@ -132,6 +132,36 @@ public class DatabaseWriteHelper {
         });
     }
 
+    public static void declineRequest(String requesterID, String bookID, Notification notification) {
+        HashMap<String, Object> updates = new HashMap<String, Object>();
+
+        final String requesterRef = String.format("requestCollection/%s/%s",
+                requesterID, bookID);
+        final String bookRequestRef = String.format("bookRequests/%s/%s",
+                bookID, requesterID);
+        final String notificationsRef = String.format("notifications/%s/%s",
+                notification.getNotificationReceiverID(),
+                notification.getNotificationID());
+
+        updates.put(requesterRef, null);
+        updates.put(bookRequestRef, null);
+        updates.put(notificationsRef, notification);
+
+        RootRefUtils.ROOT_REF.updateChildren(updates, new DatabaseReference.CompletionListener() {
+            @Override
+            public void onComplete(@Nullable DatabaseError databaseError, @NonNull DatabaseReference databaseReference) {
+                if (databaseError != null) {
+                    Log.w(TAG, "Error updating data at " + databaseReference.toString());
+                    Log.i(TAG, "bookRequestRef: " + bookRequestRef.toString());
+                    Log.i(TAG, "requesterRef: " + requesterRef.toString());
+                    Log.i(TAG, "notificationsRef: " + notificationsRef.toString());
+                } else {
+                    Log.i(TAG, "Successful update at " + databaseReference.toString());
+                }
+            }
+        });
+    }
+
     public static void deleteNotification(Notification notification) {
         deleteNotification(notification.getNotificationReceiverID(), notification.getNotificationID());
     }

--- a/app/src/main/res/drawable-v24/check.xml
+++ b/app/src/main/res/drawable-v24/check.xml
@@ -1,0 +1,8 @@
+<!-- drawable/check.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+</vector>

--- a/app/src/main/res/drawable-v24/close.xml
+++ b/app/src/main/res/drawable-v24/close.xml
@@ -1,0 +1,8 @@
+<!-- drawable/close.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" />
+</vector>

--- a/app/src/main/res/layout/request_on_book_card.xml
+++ b/app/src/main/res/layout/request_on_book_card.xml
@@ -3,15 +3,34 @@
     android:id="@+id/request_on_book_card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
+    android:orientation="horizontal"
     android:padding="15dp">
 
     <TextView
         android:id="@+id/requester_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:gravity="left"
         android:text="REQUESTER NAME HERE"
         android:textSize="16sp" />
 
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="right"
+        android:id="@+id/request_decline"
+        android:src="@drawable/close"
+        android:onClick="declineRequest"
+        />
+
+    <ImageView
+        android:id="@+id/request_accept"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="right"
+        android:gravity="right"
+        android:src="@drawable/check"
+        android:onClick="acceptRequest" />
 
 </LinearLayout>


### PR DESCRIPTION
Closes #29 
Closes #30 
Closes #32 
Fixes #146 

When an owner declines a request, the respective data from bookRequest and requestCollection in the DB is removed. The requester is also notified of the declined request.

When an owner accepts a request, the respective data from bookRequest and requestCollection in the DB is removed. The book status and book borrower ID fields in the DB is also updated. The accepted requested is also notified of the accepted request. ALL other requests are declined, so the respective data from bookRequest and requestCollection in the DB are also removed. The declined requester is also notified of the declined request.

Design decision that could potentially affect other people: Currently, the accepted requester's ID is stored in the book's borrowerID field.

Change notifications using LiveData/ViewModel to Service. 
LiveData and ViewModel both respect the lifecycle of the activity/fragment it is initialized in. This is unwanted behavior for notifications since the listener has to be active throughout the entire application. We don't know when an activity will be destroyed so we can't do anything to fix the issue if we continue using LiveData and ViewModel for notifications. (https://developer.android.com/guide/components/activities/activity-lifecycle#asem)
However, a service is independent of any activities' lifecycle.
For more info: https://developer.android.com/guide/components/services

I have not tested the longevity of said service so we could run into issues there.

Other housekeeping updates: removed userDeviceTokens code from sign in.