### PR TITLE
Change user search to partially match based on user name instead of exact matching

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'recyclerview-v7'
     }
     implementation 'com.jayway.android.robotium:robotium-solo:5.6.3'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/com/example/atheneum/fragments/SearchFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/SearchFragment.java
@@ -1,8 +1,10 @@
 package com.example.atheneum.fragments;
 
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.Observer;
+import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.MenuItemCompat;
@@ -23,16 +25,12 @@ import android.widget.Toast;
 import com.example.atheneum.R;
 import com.example.atheneum.activities.MainActivity;
 import com.example.atheneum.models.User;
-import com.google.firebase.database.DataSnapshot;
-import com.google.firebase.database.DatabaseError;
-import com.google.firebase.database.DatabaseReference;
-import com.google.firebase.database.FirebaseDatabase;
-import com.google.firebase.database.ValueEventListener;
+import com.example.atheneum.viewmodels.SearchUsersViewModel;
 
 import org.w3c.dom.Text;
 
 import java.util.ArrayList;
-
+import java.util.List;
 
 /**
  * The fragment for Searching.
@@ -43,7 +41,7 @@ import java.util.ArrayList;
 public class SearchFragment extends Fragment {
     private View view;
     private MainActivity mainActivity = null;
-    private Context context;
+    private SearchUsersViewModel searchUsersViewModel;
 
     /**
      * The User list view.
@@ -52,21 +50,9 @@ public class SearchFragment extends Fragment {
     /**
      * The User list.
      */
-    ArrayList<User> userList;
-    /**
-     * The default user list with all user names
-     */
-    ArrayList<String> defaultUserNameList = new ArrayList<>();
-    /**
-     * The Database object for Firebase
-     */
-    FirebaseDatabase db;
-    /**
-     * The reference to the Firebase Database object.
-     */
-    DatabaseReference dbRef;
+    List<User> userList;
 
-    private static final String TAG = "Search";
+    private static final String TAG = SearchFragment.class.getSimpleName();
 
     /**
      * Override onCreateView method of fragment to load search layout
@@ -82,15 +68,30 @@ public class SearchFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         this.view = inflater.inflate(R.layout.fragment_search, container, false);
 
-        this.context = getContext();
-
         if (getActivity() instanceof MainActivity) {
             mainActivity = (MainActivity) getActivity();
-            mainActivity.setActionBarTitle(context.getResources().getString(R.string.search_page_title));
+            // set action bar title
+            mainActivity.setActionBarTitle(getContext().getResources().getString(R.string.search_page_title));
         }
 
-        db = FirebaseDatabase.getInstance();
-        dbRef = db.getReference("users");
+        searchUsersViewModel = ViewModelProviders.of(getActivity()).get(SearchUsersViewModel.class);
+        LiveData<List<User>> userListLiveData = searchUsersViewModel.getUserListLiveData();
+        userListLiveData.observe(getActivity(), new Observer<List<User>>() {
+            @Override
+            public void onChanged(@Nullable List<User> users) {
+                Log.i(TAG, "in Observer!");
+                if (users != null) {
+                    Log.i(TAG, "Observer not null!");
+                    userList = users;
+                    List<String> userNameList = new ArrayList<String>();
+                    for (User user : users) {
+                        userNameList.add(user.getUserName());
+                    }
+                    ArrayAdapter<String> adapter = new ArrayAdapter<>(getActivity(), android.R.layout.simple_list_item_1, userNameList);
+                    userListView.setAdapter(adapter);
+                }
+            }
+        });
 
         userListView = (ListView) this.view.findViewById(R.id.userListView);
         userListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
@@ -112,6 +113,8 @@ public class SearchFragment extends Fragment {
                 String username = ((TextView) view.findViewById(android.R.id.text1)).getText().toString();
                 Log.d(TAG, username + " was selected");
 
+                // TODO: Refactor to make the adapter use an array of users and
+                // then display only their user names
                 db = FirebaseDatabase.getInstance();
                 dbRef = db.getReference("users");
                 dbRef.orderByChild("userName").equalTo(username).addListenerForSingleValueEvent(new ValueEventListener() {
@@ -130,31 +133,6 @@ public class SearchFragment extends Fragment {
                 });
             }
         });
-
-        userList = new ArrayList<>();
-        final ArrayList<String> userNameList = new ArrayList<>();
-
-        dbRef.addValueEventListener(new ValueEventListener() {
-            @Override
-            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-                Log.d(TAG, "On Data Change was Called");
-                for (DataSnapshot child : dataSnapshot.getChildren()) {
-                    User aUser = child.getValue(User.class);
-                    userList.add(aUser);
-                    userNameList.add(aUser.getUserName());
-                }
-                defaultUserNameList = userNameList;
-                ArrayAdapter<String> adapter = new ArrayAdapter<>(getActivity(), android.R.layout.simple_list_item_1, userNameList);
-                userListView.setAdapter(adapter);
-            }
-
-            @Override
-            public void onCancelled(@NonNull DatabaseError databaseError) {
-                System.out.println("The read failed: " + databaseError.getCode());
-            }
-        });
-
-
 
         return this.view;
     }
@@ -184,9 +162,6 @@ public class SearchFragment extends Fragment {
         inflater.inflate(R.menu.search_menu, menu);
         MenuItem item = menu.findItem(R.id.search_menu);
 
-        db = FirebaseDatabase.getInstance();
-        dbRef = db.getReference("users");
-
         item.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(MenuItem item) {
@@ -195,9 +170,6 @@ public class SearchFragment extends Fragment {
 
             @Override
             public boolean onMenuItemActionCollapse(MenuItem item) {
-                Log.d(TAG, "menu item collapse");
-                ArrayAdapter<String> adapter = new ArrayAdapter<>(getActivity(), android.R.layout.simple_list_item_1, defaultUserNameList);
-                userListView.setAdapter(adapter);
                 return true;
             }
         });
@@ -209,34 +181,13 @@ public class SearchFragment extends Fragment {
             @Override
             public boolean onQueryTextSubmit(String query) {
                 Log.d(TAG, "On Query Text Submit was Called");
-                db = FirebaseDatabase.getInstance();
-                dbRef = db.getReference("users");
-                dbRef.orderByChild("userName").equalTo(query).addListenerForSingleValueEvent(new ValueEventListener() {
-                    final ArrayList<String> userNameList = new ArrayList<>();
-                    @Override
-                    public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-                        for (DataSnapshot child : dataSnapshot.getChildren()) {
-                            User aUser = child.getValue(User.class);
-                            userList.add(aUser);
-                            userNameList.add(aUser.getUserName());
-                        }
-                        if (userNameList.isEmpty()) {
-                            Toast.makeText(getActivity(), "No exact matches found for search query", Toast.LENGTH_SHORT).show();
-                        }
-                        ArrayAdapter<String> adapter = new ArrayAdapter<>(getActivity(), android.R.layout.simple_list_item_1, userNameList);
-                        userListView.setAdapter(adapter);
-                    }
-
-                    @Override
-                    public void onCancelled(@NonNull DatabaseError databaseError) {
-                        Log.d(TAG, "On Cancelled of Options Menu");
-                    }
-                });
+                searchUsersViewModel.setUserNameQuery(query);
                 return false;
             }
 
             @Override
             public boolean onQueryTextChange(String s) {
+                searchUsersViewModel.setUserNameQuery(s);
                 return false;
             }
         });
@@ -249,6 +200,5 @@ public class SearchFragment extends Fragment {
 
         super.onCreateOptionsMenu(menu,inflater);
     }
-
 }
 

--- a/app/src/main/java/com/example/atheneum/fragments/SearchFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/SearchFragment.java
@@ -80,11 +80,9 @@ public class SearchFragment extends Fragment {
         });
 
         searchUsersViewModel = ViewModelProviders.of(getActivity()).get(SearchUsersViewModel.class);
-        LiveData<List<User>> userListLiveData = searchUsersViewModel.getUserListLiveData();
-        userListLiveData.observe(getActivity(), new Observer<List<User>>() {
+        searchUsersViewModel.getUserListLiveData().observe(getActivity(), new Observer<List<User>>() {
             @Override
             public void onChanged(@Nullable List<User> users) {
-                Log.i(TAG, "in Observer!");
                 if (users != null) {
                     userListAdapter.submitList(users);
                 }

--- a/app/src/main/java/com/example/atheneum/models/User.java
+++ b/app/src/main/java/com/example/atheneum/models/User.java
@@ -14,6 +14,7 @@ import android.app.Notification;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Objects;
 
 public class User implements Serializable {
     private String userID = "";
@@ -143,4 +144,43 @@ public class User implements Serializable {
      * @param photo
      */
     public void deletePhotos(String photo){this.photos.remove(photo);}
+
+    /**
+     * @param o Other object
+     * @return true if other object is equal to this object, false otherwise
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof User)) return false;
+        User user = (User) o;
+        return Double.compare(user.getOwnerRate(), getOwnerRate()) == 0 &&
+                Double.compare(user.getBorrowerRate(), getBorrowerRate()) == 0 &&
+                Objects.equals(getUserID(), user.getUserID()) &&
+                Objects.equals(getUserName(), user.getUserName()) &&
+                Objects.equals(getPhoneNumber(), user.getPhoneNumber()) &&
+                Objects.equals(getPhotos(), user.getPhotos());
+    }
+
+    /**
+     * @return Hash of the User object
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUserID(), getUserName(), getPhoneNumber(), getOwnerRate(), getBorrowerRate(), getPhotos());
+    }
+
+    /**
+     *
+     * @return String representation of the User object for debugging.
+     */
+    public String print() {
+        return "User{" +
+                "userID='" + userID + '\'' +
+                ", userName='" + userName + '\'' +
+                ", phoneNumber='" + phoneNumber + '\'' +
+                ", ownerRate=" + ownerRate +
+                ", borrowerRate=" + borrowerRate +
+                '}';
+    }
 }

--- a/app/src/main/java/com/example/atheneum/viewmodels/FirebaseRefUtils/UsersRefUtils.java
+++ b/app/src/main/java/com/example/atheneum/viewmodels/FirebaseRefUtils/UsersRefUtils.java
@@ -2,6 +2,7 @@ package com.example.atheneum.viewmodels.FirebaseRefUtils;
 
 import com.example.atheneum.models.User;
 import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.Query;
 
 public class UsersRefUtils extends RootRefUtils {
     public static final DatabaseReference USERS_REF = ROOT_REF.child("users");
@@ -12,5 +13,9 @@ public class UsersRefUtils extends RootRefUtils {
 
     public static final DatabaseReference getUsersRef(String userID) {
         return USERS_REF.child(userID);
+    }
+
+    public static final Query getUserNameQuery(String partialUserName) {
+        return USERS_REF.orderByChild("userName").startAt(partialUserName).endAt(partialUserName + "\uf8ff");
     }
 }

--- a/app/src/main/java/com/example/atheneum/viewmodels/SearchUsersViewModel.java
+++ b/app/src/main/java/com/example/atheneum/viewmodels/SearchUsersViewModel.java
@@ -1,0 +1,69 @@
+package com.example.atheneum.viewmodels;
+
+import android.arch.core.util.Function;
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.Transformations;
+import android.arch.lifecycle.ViewModel;
+import android.util.Log;
+
+import com.example.atheneum.models.User;
+import com.example.atheneum.utils.FirebaseQueryLiveData;
+import com.example.atheneum.viewmodels.FirebaseRefUtils.UsersRefUtils;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.Query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstracts operations on a list of users retrieved from a Firebase query and provides a LiveData stream
+ * to a View (either an Activity or Fragment). This livedata stream can be observed for changes by
+ * adding a listener and then updating the view based on the changes to the data. The list of users
+ * queried by Firebase is found by users starting with the specified partial user name.
+ */
+public class SearchUsersViewModel extends ViewModel {
+    private static final String TAG = SearchUsersViewModel.class.getSimpleName();
+
+    private FirebaseQueryLiveData queryLiveData;
+    private LiveData<List<User>> userListLiveData;
+
+    /**
+     * Create a new instance of SearchUsersViewModel
+     */
+    public SearchUsersViewModel() {
+        // Initially set the userNameQuery to search for all userNames starting with the empty string
+        // and ending with a very high Unicode character in order to match all user names in the database
+        queryLiveData = new FirebaseQueryLiveData(UsersRefUtils.getUserNameQuery(""));
+        userListLiveData = Transformations.map(queryLiveData, new Function<DataSnapshot, List<User>>() {
+            @Override
+            public List<User> apply(DataSnapshot dataSnapshot) {
+                List<User> userList = new ArrayList<User>();
+                for (DataSnapshot data : dataSnapshot.getChildren()) {
+                    userList.add(data.getValue(User.class));
+                }
+                return userList;
+            }
+        });
+    }
+
+    /**
+     * Updates the query used to search for user names starting with partialUserName.
+     *
+     * @param partialUserName New query string to pass to Firebase
+     */
+    public void setUserNameQuery(String partialUserName) {
+        Log.i(TAG, "in setUserNameQuery");
+        Query query = UsersRefUtils.getUserNameQuery(partialUserName);
+        // Updating the query will cause a change in queryLiveData which will then update
+        // userListLiveData
+        queryLiveData.updateQuery(query);
+    }
+
+    /**
+     * @return Lifecycle-aware observable stream of {@code List<User>} that the view can observe
+     *         for changes.
+     */
+    public LiveData<List<User>> getUserListLiveData() {
+        return userListLiveData;
+    }
+}

--- a/app/src/main/java/com/example/atheneum/views/adapters/UserListAdapter.java
+++ b/app/src/main/java/com/example/atheneum/views/adapters/UserListAdapter.java
@@ -1,0 +1,117 @@
+package com.example.atheneum.views.adapters;
+
+import android.support.annotation.NonNull;
+import android.support.v7.recyclerview.extensions.ListAdapter;
+import android.support.v7.util.DiffUtil;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.example.atheneum.R;
+import com.example.atheneum.models.User;
+
+/**
+ * Adapter that displays a list of users to a Recyclerview.
+ *
+ * See: https://developer.android.com/reference/android/support/v7/recyclerview/extensions/ListAdapter
+ */
+public class UserListAdapter extends ListAdapter<User, UserListAdapter.ViewHolder> {
+    // Class that is used to compare elements of new list to feed into adapter in the background
+    // thread.
+    private static final DiffUtil.ItemCallback<User> DIFF_CALLBACK = new DiffUtil.ItemCallback<User>() {
+        @Override
+        public boolean areItemsTheSame(@NonNull User user, @NonNull User other) {
+            return user.getUserID().equals(other.getUserID());
+        }
+
+        @Override
+        public boolean areContentsTheSame(@NonNull User user, @NonNull User other) {
+            return user.equals(other);
+        }
+    };
+
+    /**
+     * Custom View Holder used to display the user and deal with onClick events.
+     */
+    public class ViewHolder extends RecyclerView.ViewHolder {
+        private TextView userName;
+
+        /**
+         * Create view holder object
+         *
+         * @param view
+         */
+        public ViewHolder(@NonNull View view) {
+            super(view);
+            userName = (TextView)view.findViewById(R.id.userName);
+            view.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    User user = getItem(getAdapterPosition());
+                    if (onClickListener != null) {
+                        onClickListener.onClick(user);
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Provides an interface to handle onClick events on a User in the list
+     */
+    public interface onClickListener {
+        /**
+         * Handle onClick event on a User within the list
+         *
+         * @param user User obtained from the list contained within the Adapter
+         */
+        public void onClick(@NonNull User user);
+    }
+
+    private UserListAdapter.onClickListener onClickListener;
+
+    /**
+     * Create a new instance of UserListAdapter
+     */
+    public UserListAdapter() {
+        super(DIFF_CALLBACK);
+    }
+
+    /**
+     * Changes the on click listener
+     *
+     * @param onClickListener New on click listener
+     */
+    public void setOnClickListener(UserListAdapter.onClickListener onClickListener) {
+        this.onClickListener = onClickListener;
+    }
+
+    /**
+     *
+     *
+     * @param viewGroup
+     * @param position
+     * @return
+     */
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup viewGroup, int position) {
+        View view = LayoutInflater.from(viewGroup.getContext())
+                                  .inflate(R.layout.search_users_list_item, viewGroup, false);
+        return new ViewHolder(view);
+    }
+
+    /**
+     * Binds User object to an instance of the ViewHolder.
+     *
+     * @param holder ViewHolder object
+     * @param position Position of User within the list. User object will be bound to the ViewHolder.
+     */
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        User user = getItem(position);
+        holder.userName.setText(user.getUserName());
+    }
+}

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -8,19 +8,8 @@
     android:fitsSystemWindows="true"
     tools:openDrawer="start">
 
-    <!--<android.support.design.widget.NavigationView-->
-        <!--android:id="@+id/search_bar"-->
-        <!--android:layout_width="wrap_content"-->
-        <!--android:layout_height="match_parent"-->
-        <!--app:menu="@menu/search_menu"-->
-        <!--/>-->
-
-    <ListView
-        android:id="@+id/userListView"
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/user_recyclerview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_centerVertical="true"
-        android:layout_centerHorizontal="true"
-        />
-
+        android:layout_height="match_parent" />
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/search_users_list_item.xml
+++ b/app/src/main/res/layout/search_users_list_item.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/userName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:text="TextView"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
I made some changes to the user search fragment in order to allow the users to searched without exact matching. So if I typed "ish" in the fragment, I should receive "ishaatchowdhury@outlook.com", "ishaat@ualberta.ca", and "ishaatchowdhury@gmail.com" instead of nothing. In addition, the search results change as the user types which makes the search more intuitive for the user.

In addition, there are several related changes as part of this PR in order to improve maintainability and performance of search:
1. Modify FirebaseQueryLiveData to allow the query to be dynamically changed at runtime. This is what allows the as you type search to take place.
2. Move the Firebase querying logic to a ViewModel so that this information isn't contained in the view, making the view easier to understand and change.
3. Add a generic ListAdapter for a list of Users to interact with a RecyclerView. When the underlying list of the adapter changes by a call to submitList(), the new and old lists are diffed in a background thread improving UI responsiveness. This is provided by a Google library.
4. Use a RecyclerView to render the list of usernames instead of a ListView. Previously, a new list of usernames had to be created in order to properly render the list when using a ListView. This processing is removed by using the RecyclerView since the username of the User can be bound to the item of the userList without generating a new list of usernames to pass into an ArrayAdapter. This is an improvement in terms of speed and maintainability since RecyclerViews are in general much more efficient than ListViews.