### PR TITLE
Add Runtime Permissions Checking/Granting to PictureController

### DIFF
--- a/app/src/main/java/com/example/atheneum/fragments/EditProfileFragment.java
+++ b/app/src/main/java/com/example/atheneum/fragments/EditProfileFragment.java
@@ -7,6 +7,7 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
@@ -40,6 +41,7 @@ public class EditProfileFragment extends Fragment {
     private View view;
     private EditText phoneNumberField;
     private ImageView profilePicture;
+
     private PictureController pictureController;
     private Bitmap bitmapPhoto;
     private OnEditProfileCompleteListener editProfileCompleteListener;
@@ -224,5 +226,18 @@ public class EditProfileFragment extends Fragment {
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         pictureController.onActivityResult(requestCode, resultCode, data);
+    }
+
+    /**
+     * Handles permissions request made to this fragment
+     *
+     * @param requestCode Type of permissions request
+     * @param permissions Array of strings containing permissions requested
+     * @param grantResults Results of permissions granted
+     */
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        pictureController.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 }


### PR DESCRIPTION
Adds Runtime Permissison Checking to PictureController in order to prevent crashes when permissions are revoked.

Fixes #126 

How to test:
1. Revoke Camera permissions for Atheneum in the Android system settings
2. Log into Atheneum
3. Navigate to the edit user profile page
4. Click the profile image and deny the permission
5. Verify that the camera is not dispatched
6. Click the profile image and grant the permission
7. Verify that the camera is dispatched and that an image can be taken.
8. Verify that the image changes in the edit profile page.