### PR TITLE
Notifications redirect

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,11 +85,11 @@
             android:name=".activities.GoodreadsReviewsActivity"
             android:label="Goodreads Reviews"
             android:theme="@style/AppTheme"></activity>
-
         <activity
             android:name=".activities.ShowRequestInfoActivity"
             android:label="@string/RequestInfo"
-            android:theme="@style/AppTheme" />
+            android:theme="@style/AppTheme"
+            android:parentActivityName=".activities.MainActivity" />
         <activity
             android:name=".activities.AvailableBookInfoActivity"
             android:label="@string/AvailableBookInfo"

--- a/app/src/main/java/com/example/atheneum/activities/NotificationsActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/NotificationsActivity.java
@@ -63,7 +63,7 @@ public class NotificationsActivity extends AppCompatActivity {
             @Override
             public void onClick(@NonNull Notification notification) {
                 Log.i(TAG, "NOTIFICATION CLICKED: " + notification.getMessage());
-                //showBookInfo(notification);
+                showBookInfo(notification);
                 makeNotificationSeen(notification);
             }
         });
@@ -96,11 +96,14 @@ public class NotificationsActivity extends AppCompatActivity {
     /**
      * Starts BookInfoActivity
      */
-//    private void showBookInfo(Notification notification) {
-//        Intent showBookIntent = new Intent(getApplicationContext(), /* TODO: WAITING ON REFACTORED BOOKINFOACTIVITY */);
-//        showBookIntent.putExtra("bookID", notification.getBookID());
-//        startActivity(showBookIntent);
-//    }
+    private void showBookInfo(Notification notification) {
+        Intent showBookIntent = new Intent(getApplicationContext(), ShowRequestInfoActivity.class);
+        showBookIntent.putExtra("bookID", notification.getBookID());
+        // TODO: rStatus in ShowRequestInfoActivity should be obtained within itself
+        // BELOW IS PLACEHOLDER AND SHOULD BE THE STATUS OF THE REQUEST INSTEAD OF THE NOTIFICATION
+        showBookIntent.putExtra("rStatus", notification.getrNotificationType().toString());
+        startActivity(showBookIntent);
+    }
 
     /**
      * Make notification seen, used when user taps on notification

--- a/app/src/main/java/com/example/atheneum/activities/NotificationsActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/NotificationsActivity.java
@@ -98,10 +98,10 @@ public class NotificationsActivity extends AppCompatActivity {
      */
     private void showBookInfo(Notification notification) {
         Intent showBookIntent = new Intent(getApplicationContext(), ShowRequestInfoActivity.class);
-        showBookIntent.putExtra("bookID", notification.getBookID());
+        showBookIntent.putExtra(ShowRequestInfoActivity.BOOK_ID, notification.getBookID());
         // TODO: rStatus in ShowRequestInfoActivity should be obtained within itself
         // BELOW IS PLACEHOLDER AND SHOULD BE THE STATUS OF THE REQUEST INSTEAD OF THE NOTIFICATION
-        showBookIntent.putExtra("rStatus", notification.getrNotificationType().toString());
+        showBookIntent.putExtra(ShowRequestInfoActivity.RSTATUS, notification.getrNotificationType().toString());
         startActivity(showBookIntent);
     }
 

--- a/app/src/main/java/com/example/atheneum/activities/ShowRequestInfoActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/ShowRequestInfoActivity.java
@@ -28,20 +28,16 @@ import com.example.atheneum.viewmodels.UserViewModelFactory;
  * Show details of requests made by current user
  */
 public class ShowRequestInfoActivity extends AppCompatActivity {
+    public static final String BOOK_ID = "bookID";
+    public static final String RSTATUS = "rStatus";
+
     private TextView bookTitle;
-
     private TextView bookAuthor;
-
     private TextView bookISBN;
-
     private TextView bookStatus;
-
     private TextView bookOwner;
-
     private TextView bookDescription;
-
     private TextView RequestStatus;
-
     private Button ownerDetails;
 
     private String bookID;
@@ -51,8 +47,6 @@ public class ShowRequestInfoActivity extends AppCompatActivity {
     private static final String TAG = "ShowRequest";
 
     private BookInfoViewModel bookInfoViewModel;
-
-
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/example/atheneum/services/PushNotificationsService.java
+++ b/app/src/main/java/com/example/atheneum/services/PushNotificationsService.java
@@ -132,7 +132,7 @@ public class PushNotificationsService extends Service {
         notifyIntent.putExtra("bookID", notification.getBookID());
         // TODO: rStatus in ShowRequestInfoActivity should be obtained within itself
         // BELOW IS PLACEHOLDER AND SHOULD BE THE STATUS OF THE REQUEST INSTEAD OF THE NOTIFICATION
-        notifyIntent.putExtra("rStatus", notification.getrNotificationType());
+        notifyIntent.putExtra("rStatus", notification.getrNotificationType().toString());
         // Set the Activity to start in a new, empty task
         notifyIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 

--- a/app/src/main/java/com/example/atheneum/services/PushNotificationsService.java
+++ b/app/src/main/java/com/example/atheneum/services/PushNotificationsService.java
@@ -129,10 +129,10 @@ public class PushNotificationsService extends Service {
     private void sendNotification(Notification notification) {
 
         Intent notifyIntent = new Intent(this, ShowRequestInfoActivity.class);
-        notifyIntent.putExtra("bookID", notification.getBookID());
+        notifyIntent.putExtra(ShowRequestInfoActivity.BOOK_ID, notification.getBookID());
         // TODO: rStatus in ShowRequestInfoActivity should be obtained within itself
         // BELOW IS PLACEHOLDER AND SHOULD BE THE STATUS OF THE REQUEST INSTEAD OF THE NOTIFICATION
-        notifyIntent.putExtra("rStatus", notification.getrNotificationType().toString());
+        notifyIntent.putExtra(ShowRequestInfoActivity.RSTATUS, notification.getrNotificationType().toString());
         // Set the Activity to start in a new, empty task
         notifyIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 

--- a/app/src/main/java/com/example/atheneum/services/PushNotificationsService.java
+++ b/app/src/main/java/com/example/atheneum/services/PushNotificationsService.java
@@ -71,7 +71,7 @@ public class PushNotificationsService extends Service {
                 public void onChildAdded(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
                     Notification notification = dataSnapshot.getValue(Notification.class);
                     sendNotification(notification);
-//                    DatabaseWriteHelper.deletePushNotification(notification);
+                    DatabaseWriteHelper.deletePushNotification(notification);
                 }
 
                 @Override

--- a/app/src/main/java/com/example/atheneum/services/PushNotificationsService.java
+++ b/app/src/main/java/com/example/atheneum/services/PushNotificationsService.java
@@ -71,7 +71,7 @@ public class PushNotificationsService extends Service {
                 public void onChildAdded(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
                     Notification notification = dataSnapshot.getValue(Notification.class);
                     sendNotification(notification);
-                    DatabaseWriteHelper.deletePushNotification(notification);
+//                    DatabaseWriteHelper.deletePushNotification(notification);
                 }
 
                 @Override
@@ -134,7 +134,7 @@ public class PushNotificationsService extends Service {
         // BELOW IS PLACEHOLDER AND SHOULD BE THE STATUS OF THE REQUEST INSTEAD OF THE NOTIFICATION
         notifyIntent.putExtra("rStatus", notification.getrNotificationType().toString());
         // Set the Activity to start in a new, empty task
-        notifyIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        notifyIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
         // Create the TaskStackBuilder and add the intent, which inflates the back stack
         TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);

--- a/app/src/main/java/com/example/atheneum/services/PushNotificationsService.java
+++ b/app/src/main/java/com/example/atheneum/services/PushNotificationsService.java
@@ -2,7 +2,9 @@ package com.example.atheneum.services;
 
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
+import android.app.TaskStackBuilder;
 import android.content.Context;
 import android.content.Intent;
 import android.media.RingtoneManager;
@@ -16,6 +18,7 @@ import android.util.Log;
 
 import com.example.atheneum.R;
 import com.example.atheneum.activities.MainActivity;
+import com.example.atheneum.activities.ShowRequestInfoActivity;
 import com.example.atheneum.models.Notification;
 import com.example.atheneum.utils.FirebaseAuthUtils;
 import com.example.atheneum.viewmodels.FirebaseRefUtils.DatabaseWriteHelper;
@@ -67,7 +70,7 @@ public class PushNotificationsService extends Service {
                 @Override
                 public void onChildAdded(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
                     Notification notification = dataSnapshot.getValue(Notification.class);
-                    sendNotification(notification.getMessage());
+                    sendNotification(notification);
                     DatabaseWriteHelper.deletePushNotification(notification);
                 }
 
@@ -119,12 +122,27 @@ public class PushNotificationsService extends Service {
      * See: https://developer.android.com/guide/topics/ui/notifiers/notifications
      * See: https://developer.android.com/training/notify-user/build-notification
      * See: https://developer.android.com/training/notify-user/expanded
+     * See: https://developer.android.com/training/notify-user/navigation#java
      *
-     * @param notificationMessage
+     * @param notification
      */
-    private void sendNotification(String notificationMessage) {
-        Intent intent = new Intent(getBaseContext(), MainActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+    private void sendNotification(Notification notification) {
+
+        Intent notifyIntent = new Intent(this, ShowRequestInfoActivity.class);
+        notifyIntent.putExtra("bookID", notification.getBookID());
+        // TODO: rStatus in ShowRequestInfoActivity should be obtained within itself
+        // BELOW IS PLACEHOLDER AND SHOULD BE THE STATUS OF THE REQUEST INSTEAD OF THE NOTIFICATION
+        notifyIntent.putExtra("rStatus", notification.getrNotificationType());
+        // Set the Activity to start in a new, empty task
+        notifyIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
+        // Create the TaskStackBuilder and add the intent, which inflates the back stack
+        TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
+        stackBuilder.addNextIntentWithParentStack(notifyIntent);
+        // Get the PendingIntent containing the entire back stack
+        PendingIntent notifyPendingIntent = PendingIntent.getActivity(
+                this, 0, notifyIntent, PendingIntent.FLAG_UPDATE_CURRENT
+        );
 
         String channelId = getString(R.string.profile_title);
         Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
@@ -132,11 +150,12 @@ public class PushNotificationsService extends Service {
                 new NotificationCompat.Builder(getBaseContext(), channelId)
                         .setSmallIcon(R.drawable.ic_book_black_24dp)
                         .setContentTitle(getString(R.string.app_name))
-                        .setContentText(notificationMessage)
+                        .setContentText(notification.getMessage())
                         .setStyle(new NotificationCompat.BigTextStyle()
-                                .bigText(notificationMessage))
+                                .bigText(notification.getMessage()))
                         .setAutoCancel(true)
-                        .setSound(defaultSoundUri);
+                        .setSound(defaultSoundUri)
+                        .setContentIntent(notifyPendingIntent);
 
         NotificationManager notificationManager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);

--- a/app/src/main/java/com/example/atheneum/viewmodels/NotificationsViewModel.java
+++ b/app/src/main/java/com/example/atheneum/viewmodels/NotificationsViewModel.java
@@ -8,6 +8,7 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.example.atheneum.models.Notification;
+import com.example.atheneum.models.Request;
 import com.example.atheneum.utils.FirebaseQueryLiveData;
 import com.example.atheneum.viewmodels.FirebaseRefUtils.DatabaseWriteHelper;
 import com.example.atheneum.viewmodels.FirebaseRefUtils.NotificationsRefUtils;


### PR DESCRIPTION
Related #161 

Turns out this was an easy implementation on the notifications side. However, the Activity that the notification spawns depends on the Request's status via intent extras. Shouldn't the request status be obtained within the Activity itself?