### PR TITLE
Bookinfo fixes

### DIFF
--- a/app/src/main/java/com/example/atheneum/activities/AddEditBookActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/AddEditBookActivity.java
@@ -245,17 +245,44 @@ public class AddEditBookActivity extends AppCompatActivity {
                                 if (response.getInt("totalItems") > 0) {
                                     JSONObject firstBookInfo = response.getJSONArray("items").getJSONObject(0).getJSONObject("volumeInfo");
 
-                                    if (ctx != null) {
-                                        titleEditText.setText(firstBookInfo.getString("title"));
-                                        JSONArray authorArr = firstBookInfo.getJSONArray("authors");
-                                        String authorListString = authorArr.length() > 0 ? authorArr.getString(0) : "";
-//
-                                        for (int i = 1; i < authorArr.length(); i++) {
-                                            authorListString += ", " + authorArr.getString(i);
-                                        }
-                                        authorEditText.setText(authorListString);
+                                    int missingFields = 0;
+                                    String missingFieldsErrorMsg = "No ";
 
-                                        descEditText.setText(firstBookInfo.getString("description"));
+                                    if (ctx != null) {
+                                        if (firstBookInfo.has("title")) {
+                                            titleEditText.setText(firstBookInfo.getString("title"));
+                                        }
+                                        else {
+                                            missingFieldsErrorMsg += (missingFields == 0) ? "title " : ", title ";
+                                            missingFields++;
+                                        }
+
+                                        if (firstBookInfo.has("authors")){
+                                            JSONArray authorArr = firstBookInfo.getJSONArray("authors");
+                                            String authorListString = authorArr.length() > 0 ? authorArr.getString(0) : "";
+                                            for (int i = 1; i < authorArr.length(); i++) {
+                                                authorListString += ", " + authorArr.getString(i);
+                                            }
+                                            authorEditText.setText(authorListString);
+                                        }
+                                        else {
+                                            missingFieldsErrorMsg += (missingFields == 0) ? "authors " : ", authors ";                                            missingFields++;
+                                            missingFields++;
+                                        }
+
+                                        if (firstBookInfo.has("description")){
+                                            descEditText.setText(firstBookInfo.getString("description "));
+                                        }
+                                        else {
+                                            missingFieldsErrorMsg += (missingFields == 0) ? "description " : ", description ";
+                                            missingFields++;
+                                        }
+
+                                        // show error message if there were missing fields
+                                        if (missingFields > 0) {
+                                            missingFieldsErrorMsg += "found for the given ISBN.";
+                                            Toast.makeText(ctx, missingFieldsErrorMsg, Toast.LENGTH_LONG).show();
+                                        }
                                     }
                                 }
                                 else{

--- a/app/src/main/java/com/example/atheneum/activities/BookInfoActivity.java
+++ b/app/src/main/java/com/example/atheneum/activities/BookInfoActivity.java
@@ -1216,8 +1216,12 @@ public class BookInfoActivity extends AppCompatActivity {
             }
         }
         else if (view_type.equals(REQUSET_VIEW)) {
-            // TODO hide button if you are not the borrower
-
+            // hide button if you are not the borrower
+            FirebaseUser currentUser = FirebaseAuth.getInstance().getCurrentUser();
+            if (book.getBorrowerID() != null && currentUser != null && !book.getBorrowerID().equals(currentUser.getUid())) {
+                hideScanButtonArea();
+                return;
+            }
 
             scanBtn.setOnClickListener(new View.OnClickListener(){
                 @Override


### PR DESCRIPTION
A couple small fixes: 
Adding/editing a book that can't have  google books autofill all fields will fill what it can, and show an error toast rather than stopping as soon as it reaches an error 
Scan button no longer shows when a request is declined, or when it has been accepted for another user. 